### PR TITLE
Fix for clang-16, from FL-12402

### DIFF
--- a/llvm-kit/curated/sys-devel/clang/clang-16.0.0.ebuild
+++ b/llvm-kit/curated/sys-devel/clang/clang-16.0.0.ebuild
@@ -330,7 +330,7 @@ multilib_src_configure() {
 			-DCLANG_INCLUDE_DOCS=${build_docs}
 		)
 	fi
-	if multilib_native_use extra; then
+	if multilib_is_native_abi; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR="${WORKDIR}"/clang-tools-extra
  			-DCLANG_TOOLS_EXTRA_INCLUDE_DOCS=${build_docs}


### PR DESCRIPTION
Implements the ebuild correction from a (now unavailable) Funtoo Jira issue.