### PR TITLE
[core-kit] add app-text/asciidoc to build-time deps for genkernel

### DIFF
--- a/core-kit/curated/sys-kernel/genkernel/templates/genkernel.tmpl
+++ b/core-kit/curated/sys-kernel/genkernel/templates/genkernel.tmpl
@@ -80,6 +80,7 @@ RDEPEND="${PYTHON_DEPS}
 	virtual/pkgconfig
 	elibc_glibc? ( sys-libs/glibc[static-libs(+)] )
 	firmware? ( sys-kernel/linux-firmware )"
+BDEPEND="app-text/asciidoc"
 
 PATCHES=(
 )


### PR DESCRIPTION
Genkernel does not install on machines that don't have `a2x` (from `asciidoc`) present.