### PR TITLE
The setuptools scm autogen for version 8

### DIFF
--- a/python-modules-kit/next/dev-python/autogen.yaml
+++ b/python-modules-kit/next/dev-python/autogen.yaml
@@ -250,3 +250,30 @@ github_pythons:
             use doc && doinfo doc/info/*.info
             distutils-r1_python_install_all
           }
+
+
+setuptools_pythons:
+  generator: pypi-simple-1
+  defaults:
+    python_compat: python3+
+
+  packages:
+    - setuptools_scm:
+        rdepend: |
+          !dev-python/setuptools_scm_git_archive
+        bdepend: |
+          !!<dev-python/setuptools_scm-8.0.0
+
+        du_pep517: standalone
+        iuse: test
+
+        pydeps:
+          py:all:
+            - packaging
+            - setuptools
+            - tomli
+          py:all:build:
+            - setuptools
+          use:test:
+            - build
+            - typing_extensions


### PR DESCRIPTION
It one of dependencies to have fixed PyQt5 on MARK, issuse macaroni-os/mark-issues#14 

I performed kit-fixups PR while ago, sorry for mistakes beforehand

I used older stage3 (2024-07-15 from funtoo), because last one was on x86-64-x4 architecture

There are error message "ERROR setuptools_scm._file_finders.git listing git files failed - pretending there aren't any", but assume it safe to ignore https://github.com/pypa/setuptools_scm/issues/997#issuecomment-2032361400

doit:

```shell
$ doit --pkg setuptools_scm
INFO     Autogen: dev-python/setuptools_scm (latest)                                                                                                                                          
WARNING  dict key du_pep517 overwritten.                                                                                                                                                      
WARNING  dict key du_pep517 overwritten.                                                                                                                                                      
WARNING  dict key du_pep517 overwritten.                                                                                                                                                      
INFO     Created: setuptools_scm/setuptools_scm-8.1.0.ebuild
```

fchroot testing (it needs setuptools_scm-8 during emerge...):
```

# emerge --ask --quiet --update --changed-use --deep @world

emerge --ask --quiet --update --changed-use --deep @world
[ebuild     U ] sys-apps/iproute2-6.10.0 [6.9.0]
[ebuild     U ] net-misc/curl-8.9.1 [8.8.0]
[ebuild     U ] dev-python/pyopenssl-24.2.1 [24.1.0]
[ebuild     U ] dev-util/meson-1.5.1 [1.5.0]
[ebuild     U ] dev-vcs/git-2.46.0 [2.45.2]
[ebuild     U ] dev-lang/rust-bin-1.80.0 [1.79.0]
[ebuild     U ] virtual/rust-1.80.0 [1.79.0]
[ebuild     U ] dev-python/setuptools_scm-8.1.0 [7.1.0]
[blocks B     ] <dev-python/setuptools_scm-8.0.0 ("<dev-python/setuptools_scm-8.0.0" is hard blocking dev-python/setuptools_scm-8.1.0)

 * Error: The above package list contains packages which cannot be
 * installed at the same time on the same system.

  (dev-python/setuptools_scm-8.1.0:0/0::python-modules-kit, ebuild scheduled for merge) pulled in by
    dev-python/setuptools_scm[python_targets_python3_10(-)?,python_targets_pypy3(-)?,python_targets_python3_7(-)?,python_targets_python3_9(-)?,python_targets_python3_8(-)?,-python_single_target_python3_10(-),-python_single_target_pypy3(-),-python_single_target_python3_7(-),-python_single_target_python3_9(-),-python_single_target_python3_8(-)] (dev-python/setuptools_scm[python_targets_python3_9(-),-python_single_target_python3_10(-),-python_single_target_pypy3(-),-python_single_target_python3_7(-),-python_single_target_python3_9(-),-python_single_target_python3_8(-)]) required by (dev-python/pluggy-1.5.0:0/0::python-modules-kit, installed) USE="" PYTHON_TARGETS="python3_9 -pypy3 -python2_7 -python3_10 -python3_7 -python3_8"
    dev-python/setuptools_scm[python_targets_python3_10(-)?,python_targets_python3_7(-)?,python_targets_python3_9(-)?,python_targets_python3_8(-)?,-python_single_target_python3_10(-),-python_single_target_python3_7(-),-python_single_target_python3_9(-),-python_single_target_python3_8(-)] (dev-python/setuptools_scm[python_targets_python3_9(-),-python_single_target_python3_10(-),-python_single_target_python3_7(-),-python_single_target_python3_9(-),-python_single_target_python3_8(-)]) required by (dev-python/setuptools-rust-1.9.0:0/0::python-modules-kit, installed) USE="" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"


# emerge --unmerge dev-python/setuptools_scm

merge --ask --quiet --update --changed-use --deep @world
[ebuild     U ] sys-apps/iproute2-6.10.0 [6.9.0]
[ebuild     U ] net-misc/curl-8.9.1 [8.8.0]
[ebuild     U ] dev-python/pyopenssl-24.2.1 [24.1.0]
[ebuild     U ] dev-util/meson-1.5.1 [1.5.0]
[ebuild     U ] dev-vcs/git-2.46.0 [2.45.2]
[ebuild  N    ] dev-python/setuptools_scm-8.1.0 
[ebuild     U ] dev-lang/rust-bin-1.80.0 [1.79.0]
[ebuild     U ] virtual/rust-1.80.0 [1.79.0]

Would you like to merge these packages? [Yes/No] Y
>>> Verifying ebuild manifests
>>> Running pre-merge checks for dev-lang/rust-bin-1.80.0
>>> Emerging (1 of 8) sys-apps/iproute2-6.10.0::core-kit
>>> Installing (1 of 8) sys-apps/iproute2-6.10.0::core-kit
>>> Emerging (2 of 8) net-misc/curl-8.9.1::core-kit
>>> Installing (2 of 8) net-misc/curl-8.9.1::core-kit
>>> Emerging (3 of 8) dev-python/pyopenssl-24.2.1::python-modules-kit
>>> Installing (3 of 8) dev-python/pyopenssl-24.2.1::python-modules-kit
>>> Emerging (4 of 8) dev-util/meson-1.5.1::core-kit
>>> Installing (4 of 8) dev-util/meson-1.5.1::core-kit
>>> Emerging (5 of 8) dev-vcs/git-2.46.0::core-kit
>>> Installing (5 of 8) dev-vcs/git-2.46.0::core-kit
>>> Emerging (6 of 8) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Installing (6 of 8) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Emerging (7 of 8) dev-lang/rust-bin-1.80.0::lang-kit
>>> Installing (7 of 8) dev-lang/rust-bin-1.80.0::lang-kit
>>> Emerging (8 of 8) virtual/rust-1.80.0::lang-kit
>>> Installing (8 of 8) virtual/rust-1.80.0::lang-kit

 * Messages for package dev-vcs/git-2.46.0:

 * Please read /usr/share/bash-completion/completions/git for Git bash command
 * completion.
 * Please read /usr/share/git/git-prompt.sh for Git bash prompt
 * Note that the prompt bash code is now in that separate script
 * These additional scripts need some dependencies:
 *   git-quiltimport  : dev-util/quilt
 *   git-instaweb     : || ( www-servers/lighttpd www-servers/apache www-servers/nginx )

 * Messages for package dev-lang/rust-bin-1.80.0:

 * Rust installs a helper script for calling GDB now,
 * for your convenience it is installed under /usr/bin/rust-gdb-bin-1.80.0.


fchroot # emerge -q iniparse # install some package
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-python/iniparse-0.5::python-modules-kit
>>> Installing (1 of 1) dev-python/iniparse-0.5::python-modules-kit
>>> Recording dev-python/iniparse in "world" favorites file...

```


Closes: macaroni-os/mark-issues#25