### PR TITLE
My stab on thin-provisioning-tools

### DIFF
--- a/core-kit/curated/autogen.yaml
+++ b/core-kit/curated/autogen.yaml
@@ -27,6 +27,14 @@ github_rule:
           user: mpartel
           repo: bindfs
           query: tags
+    - thin-provisioning-tools:
+        cat: sys-block
+        github:
+          user: jthornber
+          repo: thin-provisioning-tools
+          query: tags
+        extensions:
+          - rust
 
 
 debian_rule:

--- a/core-kit/curated/sys-block/thin-provisioning-tools/files/thin-provisioning-tools-1.0.6-build-with-cargo.patch
+++ b/core-kit/curated/sys-block/thin-provisioning-tools/files/thin-provisioning-tools-1.0.6-build-with-cargo.patch
@@ -1,0 +1,21 @@
+For USE=debug to work, portage needs to run cargo_src_compile(), but if `emake`
+is used in src_install(), it will trigger a rebuild without debug.  If
+cargo_src_install() is used instead, manpages and symlinks won't be installed
+and the binary would have to be moved since there's no way to make cargo install
+to /usr/sbin. So remove $(PDATA_TOOLS) dependency in Makefile instead.  Might as
+well patch out $(STRIP) too.
+
+--- a/Makefile
++++ b/Makefile
+@@ -56,10 +56,9 @@
+ 
+ MANPAGES:=$(patsubst %,man8/%.8,$(TOOLS))
+ 
+-install: $(PDATA_TOOLS) $(MANPAGES)
++install: $(MANPAGES)
+ 	$(INSTALL_DIR) $(BINDIR)
+ 	$(INSTALL_PROGRAM) $(PDATA_TOOLS) $(BINDIR)
+-	$(STRIP) $(BINDIR)/pdata_tools
+ 	ln -s -f pdata_tools $(BINDIR)/cache_check
+ 	ln -s -f pdata_tools $(BINDIR)/cache_dump
+ 	ln -s -f pdata_tools $(BINDIR)/cache_metadata_size

--- a/core-kit/curated/templates/thin-provisioning-tools.tmpl
+++ b/core-kit/curated/templates/thin-provisioning-tools.tmpl
@@ -1,0 +1,79 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cargo llvm
+
+DESCRIPTION="A suite of tools for thin provisioning on Linux"
+HOMEPAGE="https://github.com/{{github_user}}/{{github_repo}}"
+SRC_URI="{{src_uri}}"
+
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="*"
+
+IUSE="io-uring"
+
+# for io-uring rio create needed to be different than declared in cargo.toml (exactly, from gentoo ebuild: '[rio]=https://github.com/jthornber/rio;2979a720f671e836302c01546f9cc9f7988610c8;rio-%commit%')
+# doing block by version and hope, that will be fixed in next release
+DEPEND="
+        io-uring? ( !!<=sys-block/thin-provisioning-tools-1.0.14 )
+        sys-fs/lvm2
+"
+
+# bindgen needs libclang.so 
+
+BDEPEND="${RDEPEND}
+          virtual/pkgconfig
+        >=virtual/rust-1.75
+          app-text/asciidoc 
+          sys-devel/clang
+          sys-fs/lvm2
+"
+
+
+PATCHES=(
+        "${FILESDIR}/${PN}-1.0.6-build-with-cargo.patch"
+)
+
+DOCS=(
+        CHANGES
+        COPYING
+        README.md
+        doc/TODO.md
+        doc/thinp-version-2/notes.md
+)
+
+# Rust
+QA_FLAGS_IGNORED="usr/sbin/pdata_tools"
+
+
+src_unpack() {
+	cargo_src_unpack
+	rm -rf ${S}
+	mv ${WORKDIR}/{{github_user}}-{{github_repo}}-* ${S} || die
+}
+
+src_configure() {
+        # it look like sys-devel/clang problem or llvm.eclass need update
+        export BINDGEN_EXTRA_CLANG_ARGS="${BINDGEN_EXTRA_CLANG_ARGS} -I/usr/lib/clang/$(get_llvm_slot)/include"
+
+        local myfeatures=( $(usex io-uring io_uring '') )
+        cargo_src_configure
+}
+
+src_install() {
+        # took from gentoo cargo.eclass:cargo_target_dir function
+        cargo_target_dir="${CARGO_TARGET_DIR:-target}/$(usex debug debug release)"
+
+        emake \
+                DESTDIR="${D}" \
+                DATADIR="${ED}/usr/share" \
+                PDATA_TOOLS="${cargo_target_dir}/pdata_tools" \
+                install
+
+        einstalldocs
+}
+
+

--- a/core-kit/packages.yaml
+++ b/core-kit/packages.yaml
@@ -87,7 +87,6 @@ packages:
   - sys-boot/shlilo-lantank
   - sys-boot/arcload
   - sys-block/parted
-  - sys-block/thin-provisioning-tools
   - net-mail/mailbase
   - app-misc/editor-wrapper
   - app-misc/mime-types


### PR DESCRIPTION
My stab on problem and **Please test and review ebuild before merge (my approach can be wrong)**.

 
There are few notes:
1. in rust.py written "Upon completion, metatools will create its own archive from scratch and store it in the local binary object store, and copy it to $DISTDIR for you for convenience. " -that is not very convenient  if you are not cdn
2. didn't notice crate version overrides in autogen [rust.py] (created hard block for io-uring use flag and hope that next tools version have sorted out)
3. bindgen didn't found clang headers from (/usr/lib/clang/16/include) - it can be sys-devel/clang problem
4. project have makefile and manual install method - there is missing function cargo_target_dir (like in gentoo cargo.eclass), which determines build type

as usual

```console
doit --pkg thin-provisioning-tools
INFO     Autogen: sys-block/thin-provisioning-tools (latest)                                                                                                                            
WARNING  dict key compression overwritten.                                                                                                                                              
WARNING  dict key compression overwritten.                                                                                                                                              
WARNING  dict key version overwritten.                                                                                                                                                  
WARNING  dict key version overwritten.                                                                                                                                                  
WARNING  dict key version overwritten.                                                                                                                                                  
WARNING  dict key version overwritten.                                                                                                                                                  
WARNING  dict key version overwritten.                                                                                                                                                  
WARNING  dict key version overwritten.                                                                                                                                                  
INFO     Created: sys-block/thin-provisioning-tools/thin-provisioning-tools-1.0.14.ebuild                                                                                               

as@localhost ~/proj/funtoo/kit-fixups/core-kit/curated $ git status
On branch macaroni_os_mark-issues_2
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	sys-block/thin-provisioning-tools/Manifest
	sys-block/thin-provisioning-tools/thin-provisioning-tools-1.0.14.ebuild
	../../python-modules-kit/next/dev-python/setuptools_scm/

nothing added to commit but untracked files present (use "git add" to track)
as@localhost ~/proj/funtoo/kit-fixups/core-kit/curated $ git push
Everything up-to-date

```