### PR TITLE
[HOTFIX] [kernel] Genkernel: Use a subdir of $WORKDIR for genkernel cache.

### DIFF
--- a/core-kit/next/sys-kernel/debian-sources/debian-sources-6.9.10_p1.ebuild
+++ b/core-kit/next/sys-kernel/debian-sources/debian-sources-6.9.10_p1.ebuild
@@ -316,7 +316,7 @@ src_install() {
 			--logfile=$WORKDIR/genkernel.log \
 			--kerneldir=${S} \
 			--bootdir=${D}/boot \
-			--cachedir=${D}/var/cache/genkernel \
+			--cachedir=${WORKDIR}/genkernel-cache \
 			--kernel-modules-prefix=${D} \
 			--initramfs-filename=initramfs-${KERN_SUFFIX} || \
 				die "genkernel failed:  $?" \


### PR DESCRIPTION
At the time when the host is accesssible, before sandboxing, the ${D} dir tree does not exist yet; so $WORKDIR can be used.  It was partially done in a previous commit, but not changed in the actual call to `genkernel`.  This PR fixes that Bug.