### PR TITLE
[net-kit] net-dns/coredns: Fix emerge with go1.22

### DIFF
--- a/net-kit/curated/net-dns/coredns/templates/coredns.tmpl
+++ b/net-kit/curated/net-dns/coredns/templates/coredns.tmpl
@@ -21,6 +21,7 @@ S="${WORKDIR}/{{github_user}}-{{github_repo}}-{{sha[:7]}}"
 
 src_compile() {
 	FORCE_HOST_GO=yes
+	echo "$(go env GOVERSION | sed 's/go//g')" > .go-version
 	emake
 }
 


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#52