### PR TITLE
sys-fs/zfs-kmod changes in the $DEPMOD invocation at the end of kerne…

### DIFF
--- a/core-kit/curated/sys-fs/zfs/templates/zfs-kmod.tmpl
+++ b/core-kit/curated/sys-fs/zfs/templates/zfs-kmod.tmpl
@@ -121,7 +121,7 @@ src_install() {
 	set_arch_to_kernel
 
 	myemakeargs+=(
-		DEPMOD=:
+		DEPMOD=/bin/true
 		DESTDIR="${D}"
 	)
 


### PR DESCRIPTION
…l scrips/depmod.sh broke old strategy whereby $DEPMOD was set to ":". See similar https://bugs.gentoo.org/916587

Before
![image](https://github.com/user-attachments/assets/c7a26b73-cd39-4665-bb5b-02e37e6e901e)
After
![image](https://github.com/user-attachments/assets/faa68cca-ef27-4858-ab65-67f763dd240d)
