### PR TITLE
Take 3 on setuptools_scm package

### DIFF
--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -250,3 +250,37 @@ github_pythons:
             use doc && doinfo doc/info/*.info
             distutils-r1_python_install_all
           }
+
+setuptools_pythons:
+  generator: pypi-simple-1
+  defaults:
+    python_compat: python3+
+
+  packages:
+    - setuptools_scm:
+        body : |
+          src_configure() {
+            if has_version "<dev-python/setuptools_scm-8"; then # only happens when setuptools_scm-7 is installed (main cause is duplicated entry points in similar fashion as in https://github.com/pypa/setuptools/issues/3649)
+              # it could be done better, but only side effect is two aditional internal unused api files added
+              # tested with python 3.12 - the duplicated entries where gone and update worked correctly without any quick fixes
+              ewarn "adding /src/setuptools_scm/{file_finder_git.py,file_hinder_hg.py} which point to _file_finders.{git,hg} modules due to build tools interaction"
+              echo "from ._file_finders.git import *" > ${S}/src/setuptools_scm/file_finder_git.py
+              echo "from ._file_finders.hg import *" >  ${S}/src/setuptools_scm/file_finder_hg.py
+            fi
+            distutils-r1_src_configure
+          }
+
+        du_pep517: standalone
+        iuse: test
+
+        pydeps:
+          py:all:
+            - packaging
+            - setuptools
+            - tomli
+          py:all:build:
+            - setuptools
+          use:test:
+            - build
+            - typing_extensions
+


### PR DESCRIPTION
Did more extensive tests and doesn't look like there are problem, although to be sure the rebuilding stage3 is not bad idea.

my extensive tests where:

```bash
$ cd /var/db/pkg
$ find -name "*.ebuild"|xargs grep -m1 --color=always setuptools_scm
```
and remerge these packages with updated version (interestingly is not much of them).

More about PR
============

it is one step to fix https://github.com/macaroni-os/mark-issues/issues/14 , the updated setuptools_scm necessary for dev-python/sip package upgrade which resolves problem.

The bug (duplicated entrypoints) in setuptools_scm using python 3.9 is very similar to https://github.com/pypa/setuptools/issues/3649 , only difference the bug is during install.

On other hand using python 3.12 (on Gentoo) entry points are correct.

doit
====

```bash
$ doit --release mark --pkg setuptools_scm
WARNING  dict key du_pep517 overwritten.
WARNING  dict key du_pep517 overwritten.
WARNING  dict key du_pep517 overwritten.
INFO     Autogen: dev-python/setuptools_scm (latest)
INFO     Created: setuptools_scm/setuptools_scm-8.1.0.ebuild

```

install in chroot
=============
```bash
fchroot # emerge -avq setuptools_scm
[ebuild     U ] dev-python/setuptools_scm-8.1.0 [7.1.0] USE="-test%" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8 (-python2_7%)"

Would you like to merge these packages? [Yes/No]
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Installing (1 of 1) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Recording dev-python/setuptools_scm in "world" favorites file...
>>> Jobs: 1 of 1 complete                           Load avg: 0.57, 0.43, 0.25

 * Messages for package dev-python/setuptools_scm-8.1.0:

 * adding /src/setuptools_scm/{file_finder_git.py,file_hinder_hg.py} which point to _file_finders.{git,hg} modules due to build tools interaction
fchroot # emerge -avq setuptools_scm
[ebuild   R   ] dev-python/setuptools_scm-8.1.0  USE="-test" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"

Would you like to merge these packages? [Yes/No]
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Installing (1 of 1) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Jobs: 1 of 1 complete                           Load avg: 0.75, 0.48, 0.27
fchroot #
```

demonstration with random packages
================================
testing for breakage  with 3 random python packages which have setuptools_scm dependencies ( tqdm dev-python/py dev-python/python-dateutil )

```bash
fchroot # emerge -av setuptools_scm

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild   R    ] dev-python/setuptools_scm-8.1.0::python-modules-kit  USE="-test" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8" 0 KiB

Total: 1 package (1 reinstall), Size of downloads: 0 KiB

Would you like to merge these packtqdm dev-python/py dev-python/python-dateutil
[ebuild  N    ] dev-python/tqdm-4.66.5  PYTHON_TARGETS="python3_9 -python2_7 -python3_10 -python3_7 -python3_8"
[ebuild  N    ] dev-python/py-1.11.0-r1  PYTHON_TARGETS="python3_9 -pypy3 -python2_7 -python3_10 -python3_7 -python3_8"
[ebuild  N    ] dev-python/python-dateutil-2.9.0_p0  PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"

Would you like to merge these packages? [Yes/No]
>>> Verifying ebuild manifests
>>> Emerging (1 of 3) dev-python/tqdm-4.66.5::python-modules-kit
>>> Installing (1 of 3) dev-python/tqdm-4.66.5::python-modules-kit
>>> Recording dev-python/tqdm in "world" favorites file...
>>> Emerging (2 of 3) dev-python/py-1.11.0-r1::python-modules-kit
>>> Installing (2 of 3) dev-python/py-1.11.0-r1::python-modules-kit
>>> Recording dev-python/py in "world" favorites file...
>>> Emerging (3 of 3) dev-python/python-dateutil-2.9.0_p0::python-modules-kit
>>> Installing (3 of 3) dev-python/python-dateutil-2.9.0_p0::python-modules-kit
>>> Recording dev-python/python-dateutil in "world" favorites file...
>>> Jobs: 3 of 3 complete                           Load avg: 0.49, 0.50, 0.57
fchroot # python -c "ipython -c "import tqdm;print(tqdm.__version__)" 4.66.5

```
for example tqdm uses setuptools_scm for version generation: https://github.com/tqdm/tqdm/blob/master/pyproject.toml