### PR TITLE
[python-modules-kit] dev-python/cython needs pypi name fix

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -42,7 +42,7 @@ setuptools_builds:
   generator: pypi-simple-1
   packages:
     - cython:
-        pypi_name: Cython
+        pypi_name: cython
         desc: 'A Python to C compiler'
         license: Apache-2.0
 


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#82