### PR TITLE
[bugfix] [feature] Add version-pinning to networkmanager generator & YAML

### DIFF
--- a/net-kit/next/net-misc/networkmanager/autogen.yaml
+++ b/net-kit/next/net-misc/networkmanager/autogen.yaml
@@ -3,7 +3,9 @@ networkmanager_rule:
     gitlab_user: NetworkManager
     gitlab_repo: NetworkManager
   packages:
-    - networkmanager
+    - networkmanager:
+        # Pin here at 1.48.6 until we have >=linux-headers-6.8.
+        version: '1.48.6'
 
 modemmanager_rule:
   defaults:

--- a/net-kit/next/net-misc/networkmanager/generator.py
+++ b/net-kit/next/net-misc/networkmanager/generator.py
@@ -10,7 +10,16 @@ async def generate(hub, **pkginfo):
 		f"https://gitlab.freedesktop.org/api/v4/projects/{project_path}/repository/tags", is_json=True
 	)
 	versions = [Version(tag["name"]) for tag in tags_dict if not tag["name"].upper().isupper() ]
-	version = max(versions).public
+	version = ''
+	if 'version' in pkginfo:
+		version = pkginfo['version']
+		del pkginfo['version']
+		if not Version(version) in versions:
+			print(version, versions)
+			return False
+	else:
+		version = max(versions).public
+
 	artifact = hub.pkgtools.ebuild.Artifact(
 		url=f"https://gitlab.freedesktop.org/{user}/{repo}/-/archive/{version}/{repo}-{version}.tar.bz2"
 	)


### PR DESCRIPTION
Pins NM to version `1.48.6`, the last version that builds successfully in our tree until we update our kernel headers to `>=linux-headers-6.8`.