### PR TITLE
Updated sip autogen

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -2315,12 +2315,14 @@ pep517_compliance_rule:
         du_pep517: standalone
         desc: Simplified packaging of Python modules (core module)
     - sip:
-        version: 6.8.3
-        du_pep517: generator
         license: SIP
         pydeps:
-          - packaging
-          - toml
+          py:all:build:
+            - setuptools
+            - packaging
+            - tomli
+            - setuptools_scm >= 7
+
     - pep517:
         du_pep517: flit
         pydeps:


### PR DESCRIPTION
I modified curated directly, alhough setuptools_scm are in mark directory (maybe correct this time)

as usual

```bash
 $ doit --release mark --pkg sip
WARNING  dict key du_pep517 overwritten.
WARNING  dict key du_pep517 overwritten.
INFO     Autogen: dev-python/sip (latest)
WARNING  dict key du_pep517 overwritten.
INFO     Created: sip/sip-6.8.6.ebuild

```
using stage3-generic_64-v3-next-2024-07-15.tar.xz from funtoo as base

```bash
fchroot # USE="pcre16" emerge -avq setuptools_scm sip PyQt5

 * IMPORTANT: config file '/etc/portage/package.use' needs updating.
 * See the CONFIGURATION FILES and CONFIGURATION FILES UPDATE TOOLS
 * sections of the emerge man page to learn how to update config files.
[ebuild   R   ] dev-libs/libpcre2-10.35  USE="bzip2 jit pcre16* pcre32 readline recursion-limit unicode zlib -libedit -static-libs"
[ebuild  N    ] www-client/lynx-2.9.2  USE="bzip2 ipv6 nls ssl unicode -cjk -gnutls -idn -libressl"
[ebuild  N    ] dev-python/PyQt5-sip-12.15.0  PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"
[ebuild  N    ] dev-python/PyQt-builder-1.16.4  PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"
[ebuild   R   ] dev-python/setuptools_scm-8.1.0  USE="-test" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"
[ebuild  N    ] dev-libs/double-conversion-3.1.4-r1  USE="-static-libs -test"
[ebuild  N    ] dev-python/sip-6.8.6  PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"
[ebuild  N    ] app-text/xmlto-0.0.28-r4  USE="text -latex"
[ebuild  N    ] dev-util/gdbus-codegen-2.70.0  PYTHON_SINGLE_TARGET="python3_9 -python2_7 -python3_10 -python3_7 -python3_8" PYTHON_TARGETS="python3_9 -python2_7 -python3_10 -python3_7 -python3_8"
[ebuild  N    ] dev-libs/glib-2.70.0-r2  USE="mime static-libs xattr -dbus (-fam) -gtk-doc (-selinux) -systemtap -test"
[ebuild  N    ] x11-misc/shared-mime-info-2.4
[ebuild  N    ] dev-qt/qtcore-5.15.2_p20240716  USE="icu -debug -old-kernel -test"
[ebuild  N    ] dev-qt/qtxml-5.15.2_p20240716  USE="-debug -test"
[ebuild  N    ] dev-python/PyQt5-5.15.11  USE="ssl -bluetooth -dbus -debug -declarative -designer -examples -gles2-only -gui -help -location -multimedia -network -opengl -positioning -printsupport -sensors -serialport -speech -sql -svg -testlib -webchannel -websockets -widgets -x11extras -xmlpatterns" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8"

Would you like to merge these packages? [Yes/No]
>>> Verifying ebuild manifests
>>> Running pre-merge checks for dev-qt/qtcore-5.15.2_p20240716
>>> Emerging (1 of 14) dev-libs/libpcre2-10.35::core-kit
>>> Installing (1 of 14) dev-libs/libpcre2-10.35::core-kit
>>> Emerging (2 of 14) www-client/lynx-2.9.2::browser-kit
>>> Installing (2 of 14) www-client/lynx-2.9.2::browser-kit
>>> Emerging (3 of 14) dev-python/PyQt5-sip-12.15.0::qt-kit
>>> Installing (3 of 14) dev-python/PyQt5-sip-12.15.0::qt-kit
>>> Emerging (4 of 14) dev-python/PyQt-builder-1.16.4::qt-kit
>>> Installing (4 of 14) dev-python/PyQt-builder-1.16.4::qt-kit
>>> Emerging (5 of 14) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Installing (5 of 14) dev-python/setuptools_scm-8.1.0::python-modules-kit
>>> Emerging (6 of 14) dev-libs/double-conversion-3.1.4-r1::dev-kit
>>> Installing (6 of 14) dev-libs/double-conversion-3.1.4-r1::dev-kit
>>> Emerging (7 of 14) dev-python/sip-6.8.6::python-modules-kit
>>> Installing (7 of 14) dev-python/sip-6.8.6::python-modules-kit
>>> Recording dev-python/sip in "world" favorites file...
>>> Emerging (8 of 14) app-text/xmlto-0.0.28-r4::text-kit
>>> Installing (8 of 14) app-text/xmlto-0.0.28-r4::text-kit
>>> Emerging (9 of 14) dev-util/gdbus-codegen-2.70.0::gnome-kit
>>> Installing (9 of 14) dev-util/gdbus-codegen-2.70.0::gnome-kit
>>> Emerging (10 of 14) dev-libs/glib-2.70.0-r2::gnome-kit
>>> Installing (10 of 14) dev-libs/glib-2.70.0-r2::gnome-kit
>>> Emerging (11 of 14) x11-misc/shared-mime-info-2.4::desktop-kit
>>> Installing (11 of 14) x11-misc/shared-mime-info-2.4::desktop-kit
>>> Emerging (12 of 14) dev-qt/qtcore-5.15.2_p20240716::qt-kit
>>> Installing (12 of 14) dev-qt/qtcore-5.15.2_p20240716::qt-kit
>>> Emerging (13 of 14) dev-qt/qtxml-5.15.2_p20240716::qt-kit
>>> Installing (13 of 14) dev-qt/qtxml-5.15.2_p20240716::qt-kit
>>> Emerging (14 of 14) dev-python/PyQt5-5.15.11::qt-kit
>>> Installing (14 of 14) dev-python/PyQt5-5.15.11::qt-kit
>>> Recording dev-python/PyQt5 in "world" favorites file...
>>> Jobs: 14 of 14 complete                         Load avg: 11.2, 9.6, 5.3

 * Messages for package dev-libs/libpcre2-10.35:

 * gen_usr_ldscript: Please migrate to usr-ldscript.eclass

 * Messages for package dev-util/gdbus-codegen-2.70.0:

 * Peforming directory PKG-INFO fix-up for /var/tmp/portage/dev-util/gdbus-codegen-2.70.0/image/usr/lib/python3.9/site-packages/gdbus_codegen-2.70.0-py3.9.egg-info...

 * Messages for package dev-qt/qtcore-5.15.2_p20240716:

 * Generated gentoo-qconfig.h is empty

 * Messages for package dev-qt/qtxml-5.15.2_p20240716:

 * Generated gentoo-qconfig.h is empty

 * IMPORTANT: config file '/etc/portage/package.use' needs updating.
 * See the CONFIGURATION FILES and CONFIGURATION FILES UPDATE TOOLS
 * sections of the emerge man page to learn how to update config files.
```

Closes: macaroni-os/mark-issues#25