### PR TITLE
=net-ftp/filezilla-3.67.1 and dev-libs/libfilezilla-0.48.1 prevent tree  regeneration

### DIFF
--- a/dev-kit/curated/dev-libs/libfilezilla/autogen.py
+++ b/dev-kit/curated/dev-libs/libfilezilla/autogen.py
@@ -21,6 +21,6 @@ async def generate(hub, **pkginfo):
     ebuild = hub.pkgtools.ebuild.BreezyBuild(
         **pkginfo,
         version=version,
-        artifacts=[hub.pkgtools.ebuild.Artifact(url=url, final_name=final_name)]
+        artifacts=[hub.pkgtools.ebuild.Artifact(url=url, final_name=final_name, extra_http_headers={"User-Agent" : "Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0"})]
     )
     ebuild.push()

--- a/net-kit/curated/net-ftp/filezilla/autogen.py
+++ b/net-kit/curated/net-ftp/filezilla/autogen.py
@@ -21,6 +21,6 @@ async def generate(hub, **pkginfo):
     ebuild = hub.pkgtools.ebuild.BreezyBuild(
         **pkginfo,
         version=version,
-        artifacts=[hub.pkgtools.ebuild.Artifact(url=url, final_name=final_name)]
+        artifacts=[hub.pkgtools.ebuild.Artifact(url=url, final_name=final_name, extra_http_headers={"User-Agent" : "Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0"})]
     )
     ebuild.push()


### PR DESCRIPTION
Summary
========
* Seems like the page is expecting a 'User-Agent' header in the request from now
* This closing https://github.com/macaroni-os/mark-issues/issues/108

Test Plan
========
* Doit
```
 ╰ $ doit
INFO     Autogen: net-ftp/filezilla (latest)                                                                                                                                                                                                                                                                        
INFO     Download from https://dl1.cdn.filezilla-project.org/client/FileZilla_3.67.1_src.tar.xz?h=smZwSoLKpKnNpdLs2Hag5A&x=1725052174 verified as valid tar.xz archive.                                                                                                                                             
INFO     Created: filezilla-3.67.1.ebuild    

 ╰ $ doit
INFO     Autogen: dev-libs/libfilezilla (latest)                                                                                                                                                                                                                                                                    
INFO     Download from https://dl4.cdn.filezilla-project.org/libfilezilla/libfilezilla-0.48.1.tar.xz?h=cpCNmqYM2ng7H_3IT1dKfw&x=1725053659 verified as valid tar.xz archive.                                                                                                                                        
INFO     Created: libfilezilla-0.48.1.ebuild     

```
