### PR TITLE
[media-kit] media-sound/mpd - fix compilation with fmt 11

### DIFF
--- a/media-kit/mark/media-sound/mpd/files/040-lib-fmt-support-build-with-libfmt-11.0.0.patch
+++ b/media-kit/mark/media-sound/mpd/files/040-lib-fmt-support-build-with-libfmt-11.0.0.patch
@@ -1,0 +1,72 @@
+From 1402869715e3efca87942d79c3173a6b21a6925d Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 5 Jul 2024 14:27:45 +0000
+Subject: [PATCH 1/1] lib/fmt: support build with libfmt-11.0.0
+
+Upstream libfmt commit fmtlib/fmt@d707292
+now requires the format function to be const.
+
+Adjust the function prototype so it is const and can compile.
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>
+---
+ src/lib/ffmpeg/LibFmt.hxx            | 2 +-
+ src/lib/fmt/AudioFormatFormatter.hxx | 4 ++--
+ src/lib/fmt/ExceptionFormatter.hxx   | 2 +-
+ src/lib/fmt/PathFormatter.hxx        | 2 +-
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+--- a/src/lib/ffmpeg/LibFmt.hxx
++++ b/src/lib/ffmpeg/LibFmt.hxx
+@@ -29,7 +29,7 @@ template<>
+ struct fmt::formatter<AVSampleFormat> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(const AVSampleFormat format, FormatContext &ctx) {
++	auto format(const AVSampleFormat format, FormatContext &ctx) const {
+ 		const char *name = av_get_sample_fmt_name(format);
+ 		if (name == nullptr)
+ 			name = "?";
+--- a/src/lib/fmt/AudioFormatFormatter.hxx
++++ b/src/lib/fmt/AudioFormatFormatter.hxx
+@@ -39,7 +39,7 @@ template<>
+ struct fmt::formatter<SampleFormat> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(const SampleFormat format, FormatContext &ctx) {
++	auto format(const SampleFormat format, FormatContext &ctx) const {
+ 		return formatter<string_view>::format(sample_format_to_string(format),
+ 						      ctx);
+ 	}
+@@ -49,7 +49,7 @@ template<>
+ struct fmt::formatter<AudioFormat> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(const AudioFormat &af, FormatContext &ctx) {
++	auto format(const AudioFormat &af, FormatContext &ctx) const {
+ 		return formatter<string_view>::format(ToString(af).c_str(),
+ 						      ctx);
+ 	}
+--- a/src/lib/fmt/ExceptionFormatter.hxx
++++ b/src/lib/fmt/ExceptionFormatter.hxx
+@@ -38,7 +38,7 @@ template<>
+ struct fmt::formatter<std::exception_ptr> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(std::exception_ptr e, FormatContext &ctx) {
++	auto format(std::exception_ptr e, FormatContext &ctx) const {
+ 		return formatter<string_view>::format(GetFullMessage(e), ctx);
+ 	}
+ };
+--- a/src/lib/fmt/PathFormatter.hxx
++++ b/src/lib/fmt/PathFormatter.hxx
+@@ -29,7 +29,7 @@ template<>
+ struct fmt::formatter<Path> : formatter<string_view>
+ {
+ 	template<typename FormatContext>
+-	auto format(Path path, FormatContext &ctx) {
++	auto format(Path path, FormatContext &ctx) const {
+ 		return formatter<string_view>::format(path.ToUTF8(), ctx);
+ 	}
+ };

--- a/media-kit/mark/media-sound/mpd/files/mpd-fmt11_e380ae9.patch
+++ b/media-kit/mark/media-sound/mpd/files/mpd-fmt11_e380ae9.patch
@@ -1,0 +1,21 @@
+commit e380ae90ebb6325d1820b6f34e10bf3474710899
+Author: Max Kellermann <max.kellermann@gmail.com>
+Date:   Sun Jul 7 10:09:08 2024 +0200
+
+    Log: add missing include for std::back_inserter()
+    
+    Closes https://github.com/MusicPlayerDaemon/MPD/issues/2071
+
+diff --git a/src/Log.cxx b/src/Log.cxx
+index d5a3db2aa..78e0efb54 100644
+--- a/src/Log.cxx
++++ b/src/Log.cxx
+@@ -8,6 +8,8 @@
+ 
+ #include <fmt/format.h>
+ 
++#include <iterator> // for std::back_inserter()
++
+ static constexpr Domain exception_domain("exception");
+ 
+ void

--- a/media-kit/mark/media-sound/mpd/templates/mpd.tmpl
+++ b/media-kit/mark/media-sound/mpd/templates/mpd.tmpl
@@ -6,7 +6,7 @@ inherit flag-o-matic linux-info meson xdg-utils user
 
 DESCRIPTION="The Music Player Daemon (mpd)"
 HOMEPAGE="https://www.musicpd.org https://github.com/MusicPlayerDaemon/MPD"
-SRC_URI="{{ artifacts[0].src_uri }}"
+SRC_URI="{{ src_uri }}"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -106,6 +106,11 @@ DEPEND="${RDEPEND}
 
 BDEPEND=">=dev-util/meson-0.49.2
 	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/040-lib-fmt-support-build-with-libfmt-11.0.0.patch
+	"${FILESDIR}"/mpd-fmt11_e380ae9.patch
+)
 
 post_src_unpack() {
 	if [ ! -d "${S}" ]; then
@@ -300,3 +305,5 @@ pkg_postinst() {
 pkg_postrm() {
 	xdg_icon_cache_update
 }
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#113

Tested on macaroni-funtoo tree. The package is available in Phoenix 24.08.