### PR TITLE
=app-emulation/virtualbox-bin-7.1.0 breaks tree autogen

### DIFF
--- a/core-kit/curated/app-emulation/virtualbox-bin/autogen.py
+++ b/core-kit/curated/app-emulation/virtualbox-bin/autogen.py
@@ -13,7 +13,7 @@ async def generate(hub, **pkginfo):
 	svn_ver = match.group(1)
 	version = f"{main_ver}.{svn_ver}"
 	urlbin = f"https://download.virtualbox.org/virtualbox/{main_ver}/{match.group(0)}"
-	urlext = f"https://download.virtualbox.org/virtualbox/{main_ver}/Oracle_VM_VirtualBox_Extension_Pack-{main_ver}.vbox-extpack"
+	urlext = f"https://download.virtualbox.org/virtualbox/{main_ver}/Oracle_VirtualBox_Extension_Pack-{main_ver}.vbox-extpack"
 	urlsdk = f"https://download.virtualbox.org/virtualbox/{main_ver}/VirtualBoxSDK-{main_ver}-{svn_ver}.zip"
 	urladd = f"https://download.virtualbox.org/virtualbox/{main_ver}/VBoxGuestAdditions_{main_ver}.iso"
 	urlgst = f"https://download.virtualbox.org/virtualbox/{main_ver}/VirtualBox-{main_ver}.tar.bz2"


### PR DESCRIPTION
The url for extension pack has been changed from
`https://download.virtualbox.org/virtualbox/7.1.0/Oracle_VM_VirtualBox_Extension_Pack-7.1.0.vbox-extpack`
to 
`https://download.virtualbox.org/virtualbox/7.1.0/Oracle_VirtualBox_Extension_Pack-7.1.0.vbox-extpack`

See https://download.virtualbox.org/virtualbox/7.1.0/
