### PR TITLE
[python-modules-kit] dev-python/sqlalchemy fix pypi name

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -50,7 +50,6 @@ sqlalchemy:
   generator: pypi-compat-1
   packages:
     - sqlalchemy:
-        pypi_name: SQLAlchemy
         du_pep517: setuptools
         pydeps:
           py:all:


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#122