### PR TITLE
[games-kit] Update to `odamex-10.6.0` and improve media mix-in

### DIFF
--- a/core-kit/curated/profiles/funtoo/1.0/linux-gnu/mix-ins/media/package.use
+++ b/core-kit/curated/profiles/funtoo/1.0/linux-gnu/mix-ins/media/package.use
@@ -5,3 +5,6 @@ app-text/poppler cairo
 # Required by media-sound/cantata, to ease conflict with default
 # inherited from mediadevice-base mix-in
 media-sound/cantata -cdda -cddb -cdio
+
+# Required by games-engines/odamex, for midi music
+media-libs/sdl2-mixer midi timidity

--- a/games-kit/curated/autogen.yaml
+++ b/games-kit/curated/autogen.yaml
@@ -75,11 +75,12 @@ doom_github_rule:
               query: releases
             tarball: odamex-src-{version}.tar.xz
             keywords: '*'
-          '10.5.0_p20240801':
-            github:
-              query: snapshot
-              snapshot: '2e3e8dd36e2a596fec0bf2049b4daaeaf8e4139e'
-            keywords: '~'
+          # An example of a snapshot version:
+          #'10.5.0_p20240801':
+          #  github:
+          #    query: snapshot
+          #    snapshot: '2e3e8dd36e2a596fec0bf2049b4daaeaf8e4139e'
+          #  keywords: '~'
     - freedoom:
         cat: games-fps
         desc: A complete free-content single-player focused game based on the Doom engine

--- a/games-kit/curated/templates/odamex.tmpl
+++ b/games-kit/curated/templates/odamex.tmpl
@@ -21,11 +21,16 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="{{ keywords }}"
 IUSE="+client hidpi master +odalaunch server upnp X"
-REQUIRED_USE="|| ( client master server )"
+REQUIRED_USE="
+	|| ( client master server )
+	odalaunch? ( X )
+"
 
 # protobuf is still bundled. Unfortunately an old version is required for C++98
 # compatibility. We could use C++11, but upstream is concerned about using a
 # completely different protobuf version on a multiplayer-focused engine.
+
+# Note that X 
 
 RDEPEND="
 	net-misc/curl
@@ -36,13 +41,14 @@ RDEPEND="
 		media-libs/sdl2-mixer[midi,timidity]
 		net-misc/curl
 		!hidpi? ( x11-libs/fltk:1 )
-		X? ( x11-libs/libX11 )
 	)
 	odalaunch? ( x11-libs/wxGTK:${WX_GTK_VER}[X] )
 	server? (
 		dev-libs/jsoncpp:=
 		upnp? ( net-libs/miniupnpc:= )
-	)"
+	)
+	X? ( x11-libs/libX11 )
+"
 DEPEND="${RDEPEND}"
 BDEPEND="
 	>=dev-util/cmake-3.13
@@ -53,9 +59,13 @@ DOC_CONTENTS="
 	Check: http://odamex.net/wiki/FAQ#What_data_files_are_required.3F
 "
 
+{% if github['snapshot'] is not defined %}
+S="${WORKDIR}/${PN}-src-${PV}"
+{%- else %}
 S="${WORKDIR}/${PN}-${PV}"
+{%- endif %}
 
-{%- if patches %}
+{%- if patches is defined %}
 PATCHES=(
 {%- for patch in patches %}
 	"${FILESDIR}"/"${PN}-{{ patch }}"


### PR DESCRIPTION
Change in the mix-in adds `USE="midi timidity"` to `sdl2-mixer`, so that Odamex can be installed without setting USE flags.

I've tested this patch in my local tree and expect that it will behave nicely.