### PR TITLE
[core-kit] sys-apps/busybox autogen review

### DIFF
--- a/core-kit/curated/sys-apps/busybox/autogen.yaml
+++ b/core-kit/curated/sys-apps/busybox/autogen.yaml
@@ -1,11 +1,10 @@
 busybox:
-  generator: github-1
+  generator: dirlisting-1
   packages:
     - busybox:
-        github:
-          user: mirror
-          query: tags
-          transform:
-            - kind: string
-              match: _
-              replace: .
+        dir:
+          url: https://busybox.net/downloads/
+          format: tar.bz2
+          order: asc
+          files:
+            - busybox

--- a/core-kit/curated/sys-apps/busybox/files/busybox-1.36.1-no-cbq.patch
+++ b/core-kit/curated/sys-apps/busybox/files/busybox-1.36.1-no-cbq.patch
@@ -1,0 +1,49 @@
+diff -up busybox-1.36.1/networking/tc.c.no-cbq busybox-1.36.1/networking/tc.c
+--- busybox-1.36.1/networking/tc.c.no-cbq	2024-01-29 10:24:09.135082923 -0500
++++ busybox-1.36.1/networking/tc.c	2024-01-29 10:28:12.009502552 -0500
+@@ -31,7 +31,7 @@
+ //usage:	"qdisc [handle QHANDLE] [root|"IF_FEATURE_TC_INGRESS("ingress|")"parent CLASSID]\n"
+ /* //usage: "[estimator INTERVAL TIME_CONSTANT]\n" */
+ //usage:	"	[[QDISC_KIND] [help|OPTIONS]]\n"
+-//usage:	"	QDISC_KIND := [p|b]fifo|tbf|prio|cbq|red|etc.\n"
++//usage:	"	QDISC_KIND := [p|b]fifo|tbf|prio|red|etc.\n"
+ //usage:	"qdisc show [dev STRING]"IF_FEATURE_TC_INGRESS(" [ingress]")"\n"
+ //usage:	"class [classid CLASSID] [root|parent CLASSID]\n"
+ //usage:	"	[[QDISC_KIND] [help|OPTIONS] ]\n"
+@@ -230,7 +230,7 @@ static int cbq_parse_opt(int argc, char
+ {
+ 	return 0;
+ }
+-#endif
++
+ static int cbq_print_opt(struct rtattr *opt)
+ {
+ 	struct rtattr *tb[TCA_CBQ_MAX+1];
+@@ -322,6 +322,7 @@ static int cbq_print_opt(struct rtattr *
+  done:
+ 	return 0;
+ }
++#endif
+ 
+ static FAST_FUNC int print_qdisc(
+ 		const struct sockaddr_nl *who UNUSED_PARAM,
+@@ -373,7 +374,8 @@ static FAST_FUNC int print_qdisc(
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			prio_print_opt(tb[TCA_OPTIONS]);
+ 		} else if (qqq == 1) { /* class based queuing */
+-			cbq_print_opt(tb[TCA_OPTIONS]);
++			/* cbq_print_opt(tb[TCA_OPTIONS]); */
++			printf("cbq not supported");
+ 		} else {
+ 			/* don't know how to print options for this qdisc */
+ 			printf("(options for %s)", name);
+@@ -444,7 +446,8 @@ static FAST_FUNC int print_class(
+ 			/* nothing. */ /*prio_print_opt(tb[TCA_OPTIONS]);*/
+ 		} else if (qqq == 1) { /* class based queuing */
+ 			/* cbq_print_copt() is identical to cbq_print_opt(). */
+-			cbq_print_opt(tb[TCA_OPTIONS]);
++			/* cbq_print_opt(tb[TCA_OPTIONS]); */
++			printf("cbq not supported");
+ 		} else {
+ 			/* don't know how to print options for this class */
+ 			printf("(options for %s)", name);

--- a/core-kit/curated/sys-apps/busybox/templates/busybox.tmpl
+++ b/core-kit/curated/sys-apps/busybox/templates/busybox.tmpl
@@ -8,7 +8,7 @@ inherit flag-o-matic savedconfig toolchain-funcs
 
 DESCRIPTION="Utilities for rescue and embedded systems"
 HOMEPAGE="https://www.busybox.net/"
-SRC_URI="{{ artifacts[0].src_uri }}"
+SRC_URI="{{ src_uri }}"
 KEYWORDS="*"
 
 LICENSE="GPL-2" # GPL-2 only
@@ -62,7 +62,7 @@ busybox_config_enabled() {
 # patches go here!
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.26.2-bb.patch
-	# "${FILESDIR}"/${P}-*.patch
+	"${FILESDIR}"/${PN}-1.36.1-no-cbq.patch
 )
 
 src_prepare() {
@@ -327,3 +327,5 @@ pkg_postinst() {
 		elog "     init=/ginit bb"
 	fi
 }
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Using `dirlisting-1` generator and add patch
for CBQ feature removed.

Closes: macaroni-os/mark-issues#123