### PR TITLE
sci-mathematics/rstudio-bin

### DIFF
--- a/science-kit/curated/sci-mathematics/rstudio-bin/autogen.py
+++ b/science-kit/curated/sci-mathematics/rstudio-bin/autogen.py
@@ -4,10 +4,8 @@ from bs4 import BeautifulSoup
 import re
 
 async def generate(hub, **pkginfo):
-	html_data = await hub.pkgtools.fetch.get_page(
-		f"https://www.rstudio.com/products/rstudio/download/"
-		)
-	soup = BeautifulSoup(html_data, "html.parser")
+	html_data = await hub.pkgtools.fetch.get_page(f"https://posit.co/download/rstudio-desktop/")
+	soup: BeautifulSoup = BeautifulSoup(html_data, "html.parser")
 	best_archive = None
 	for link in soup.find_all("a"):
 		href = link.get("href")


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#126

```
 ╰ $ doit
INFO     Autogen: sci-mathematics/rstudio-bin (latest)                                                                                                                                                                                                                                                              
INFO     Download from https://download1.rstudio.org/electron/focal/amd64/rstudio-2024.04.2-764-amd64-debian.tar.gz verified as valid tar.gz archive.                                                                                                                                                               
INFO     Created: rstudio-bin-2024.04.2.764.ebuild   ```

