### PR TITLE
app-eselect/eselect-java

### DIFF
--- a/core-kit/next/app-eselect/eselect-java/Manifest
+++ b/core-kit/next/app-eselect/eselect-java/Manifest
@@ -1,0 +1,1 @@
+DIST eselect-java-0.5.1.tar.gz 15205 SHA512 3425669adbd68f1ed148d04a1a8dbed2fdc212edf973ac3f1e9658dafe1cad6a69683baf558e91381eb5833f8cb3cf2c6ec32bfb93d288e72cd332b0cd1c60a7

--- a/core-kit/next/app-eselect/eselect-java/eselect-java-0.5.1.ebuild
+++ b/core-kit/next/app-eselect/eselect-java/eselect-java-0.5.1.ebuild
@@ -1,0 +1,38 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools
+
+DESCRIPTION="A set of eselect modules for Java"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Java"
+SRC_URI="https://gitweb.gentoo.org/proj/${PN}.git/snapshot/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 ~arm arm64 ppc64 x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+        !app-eselect/eselect-ecj
+        !app-eselect/eselect-maven
+        !<dev-java/java-config-2.2
+        app-admin/eselect"
+
+src_prepare() {
+        default
+        eautoreconf
+}
+
+pkg_postinst() {
+        local REMOVED=0
+
+        rm -v "${EROOT}"usr/lib*/nsbrowser/plugins/javaplugin.so 2>/dev/null && REMOVED=1
+        rm -v "${EROOT}"etc/java-config-2/current-icedtea-web-vm 2>/dev/null && REMOVED=1
+
+        if [[ ${REMOVED} = 1 ]]; then
+                elog "The eselect java-nsplugin module has been removed and your configuration"
+                elog "has been cleaned up. From now on, you may only install either Oracle or"
+                elog "IcedTea's plugin but not both. Note you can use IcedTea's plugin with an"
+                elog "Oracle VM. See the README installed with icedtea-web for more details."
+        fi
+}

--- a/core-kit/next/app-eselect/eselect-java/eselect-java-0.5.1.ebuild
+++ b/core-kit/next/app-eselect/eselect-java/eselect-java-0.5.1.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://gitweb.gentoo.org/proj/${PN}.git/snapshot/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ppc64 x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="*"
 
 RDEPEND="
         !app-eselect/eselect-ecj

--- a/core-kit/next/packages.yaml
+++ b/core-kit/next/packages.yaml
@@ -87,7 +87,6 @@ packages:
   - app-eselect/eselect-fontconfig
   - app-eselect/eselect-gnome-shell-extensions
   - app-eselect/eselect-infinality
-  - app-eselect/eselect-java
   - app-eselect/eselect-lapack
   - app-eselect/eselect-lcdfilter
   - app-eselect/eselect-lib-bin-symlink

--- a/core-kit/next/packages.yaml.wip
+++ b/core-kit/next/packages.yaml.wip
@@ -393,7 +393,6 @@ packages:
   - app-eselect/eselect-lib-bin-symlink
   - app-eselect/eselect-infinality
   - app-eselect/eselect-unison
-  - app-eselect/eselect-java
   - app-eselect/eselect-timidity
   - app-eselect/eselect-php
   - app-eselect/eselect-emacs

--- a/core-kit/packages.yaml
+++ b/core-kit/packages.yaml
@@ -349,7 +349,6 @@ packages:
   - app-eselect/eselect-lib-bin-symlink
   - app-eselect/eselect-infinality
   - app-eselect/eselect-unison
-  - app-eselect/eselect-java
   - app-eselect/eselect-timidity
   - app-eselect/eselect-php
   - app-eselect/eselect-emacs


### PR DESCRIPTION
Summary
========
* static ebuild added
* deleted from gentoo stage
* Closes: macaroni-os/mark-issues#130

Test Plan
========
* Doit
```
 ╰ $ ebuild eselect-java-0.5.1.ebuild digest
Appending /home/borisp/Development/src/funtoo-infra-core/kit-fixups/core-kit/next to PORTDIR_OVERLAY...
>>> Downloading 'https://gitweb.gentoo.org/proj/eselect-java.git/snapshot/eselect-java-0.5.1.tar.gz'
--2024-09-19 21:58:42--  https://gitweb.gentoo.org/proj/eselect-java.git/snapshot/eselect-java-0.5.1.tar.gz
Resolving gitweb.gentoo.org... 146.75.121.91, 2a04:4e42:8d::347
Connecting to gitweb.gentoo.org|146.75.121.91|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 15205 (15K) [application/x-gzip]
Saving to: ‘/var/cache/portage/distfiles/eselect-java-0.5.1.tar.gz.__download__’

/var/cache/portage/distfiles/eselect-java-0.5.1.tar.gz.__download__          100%[==============================================================================================================================================================================================>]  14,85K  --.-KB/s    in 0,001s  

2024-09-19 21:58:42 (23,1 MB/s) - ‘/var/cache/portage/distfiles/eselect-java-0.5.1.tar.gz.__download__’ saved [15205/15205]

>>> Creating Manifest for /home/borisp/Development/src/funtoo-infra-core/kit-fixups/core-kit/next/app-eselect/eselect-java

```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
Updating profiles at /etc/portage/make.profile/parent...
Updating non-funtoo repositories...
Sync successful and kits in alignment! :)

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] app-eselect/eselect-java-0.5.1::core-kit [0.4.0::core-kit] 0 KiB
[ebuild  NS    ] sys-kernel/debian-sources-6.10.9_p1:debian-sources-6.10.9_p1::core-kit [6.10.7_p1:debian-sources-6.10.7_p1::core-kit] USE="binary custom-cflags logo sign-modules zfs -acpi-ec -btrfs -ec2 -luks -lvm -ramdisk -savedconfig" 0 KiB

Total: 2 packages (1 upgrade, 1 in new slot), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Running pre-merge checks for sys-kernel/debian-sources-6.10.9_p1
 * Checking for at least 6 GiB disk space at "/run/portage/sys-kernel/debian-sources-6.10.9_p1/temp" ...                                                                                                                                                                           [ ok ]
>>> Emerging (1 of 2) app-eselect/eselect-java-0.5.1::core-kit
>>> Installing (1 of 2) app-eselect/eselect-java-0.5.1::core-kit
>>> Emerging (2 of 2) sys-kernel/debian-sources-6.10.9_p1::core-kit
>>> Installing (2 of 2) sys-kernel/debian-sources-6.10.9_p1::core-kit
>>> Jobs: 2 of 2 complete                           Load avg: 5.8, 30.2, 23.3


```