### PR TITLE
adding go1.22.7 and go1.23.1

### DIFF
--- a/lang-kit/curated/dev-lang/autogen.yaml
+++ b/lang-kit/curated/dev-lang/autogen.yaml
@@ -7,7 +7,7 @@ go_gen:
   packages:
     - go:
         versions:
-          1.22.5:
+          1.23.1:
             unmasked: True
-          1.21.12:
+          1.22.7:
             unmasked: True


### PR DESCRIPTION
Summary
========
* Closes: https://github.com/macaroni-os/mark-issues/issues/131
* This updates MARK to the latest upstream Go stable versions: Go 1.23.1 and 1.22.7

Test Plan
=======

I unfortunately cannot test this properly as I cannot get the forked funtoo-metatools to even work with the new MARK kit-fixups:
```
doit --cat dev-lang --pkg go
Traceback (most recent call last):
  File "/home/ss/Repos/funtoo-metatools-macaroni/bin/doit", line 102, in <module>
    success = asyncio.run(main_thread())
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/home/ss/Repos/funtoo-metatools-macaroni/bin/doit", line 91, in main_thread
    await pkgtools.launch(AutogenConfig, **kwargs)
  File "/home/ss/Repos/subpop/subpop/util.py", line 327, in launch
    await self.model.start(**config_kwargs)
  File "/home/ss/Repos/subpop/subpop/config.py", line 69, in start
    await self.initialize(**config_kwargs)
  File "/home/ss/Repos/funtoo-metatools-macaroni/metatools/config/autogen.py", line 169, in initialize
    self.release_yaml = ReleaseYAML(release=release, prod=prod, kit_fixups=self.kit_fixups_repo)
  File "/home/ss/Repos/funtoo-metatools-macaroni/metatools/release.py", line 400, in __init__
    raise ConfigurationError(f"Cannot find expected {filename}")
subpop.config.ConfigurationError: Cannot find expected /home/ss/Repos/kit-fixups-macaroni/releases/next/repositories.yaml
```
If there is proper documentation on how to test MARK kit-fixups changes please link to it.