### PR TITLE
sys-apps/fwupd

### DIFF
--- a/core-hw-kit/curated/sys-apps/fwupd/autogen.yaml
+++ b/core-hw-kit/curated/sys-apps/fwupd/autogen.yaml
@@ -8,15 +8,11 @@ fwupd_rule:
           user: fwupd
           repo: fwupd
           query: releases
-        select: '1.7.7'
     - fwupd-efi:
-        revision:
-          '1.4': 1
         github:
           user: fwupd
           repo: fwupd-efi
           query: releases
-          tarball: fwupd-efi-{version}.tar.xz
 python_mods_rule:
   generator: pypi-compat-1
   defaults:

--- a/core-hw-kit/curated/sys-apps/fwupd/templates/fwupd.tmpl
+++ b/core-hw-kit/curated/sys-apps/fwupd/templates/fwupd.tmpl
@@ -107,7 +107,7 @@ src_prepare() {
 		-i plugins/meson.build || die #753521
 
 	sed -e "/install_dir.*'doc'/s/fwupd/${PF}/" \
-		-i data/builder/meson.build || die
+		-i data/meson.build || die
 
 	vala_src_prepare
 }
@@ -115,8 +115,6 @@ src_prepare() {
 src_configure() {
 	local plugins=(
 		-Dplugin_gpio="true"
-		$(meson_use amt plugin_amt)
-		$(meson_use dell plugin_dell)
 		$(meson_use fastboot plugin_fastboot)
 		$(meson_use flashrom plugin_flashrom)
 		$(meson_use gusb plugin_uf2)
@@ -127,7 +125,6 @@ src_configure() {
 		$(meson_use spi plugin_intel_spi)
 		$(meson_use synaptics plugin_synaptics_mst)
 		$(meson_use synaptics plugin_synaptics_rmi)
-		$(meson_use thunderbolt plugin_thunderbolt)
 		$(meson_use tpm plugin_tpm)
 		$(meson_use uefi plugin_uefi_capsule)
 		$(meson_use uefi plugin_uefi_capsule_splash)
@@ -172,6 +169,6 @@ src_install() {
 
 		# Don't timeout when fwupd is running (#673140)
 		sed '/^IdleTimeout=/s@=[[:digit:]]\+@=0@' \
-			-i "${ED}"/etc/${PN}/daemon.conf || die
+			-i "${ED}"/etc/${PN}/fwupd.conf || die
 	fi
 }


### PR DESCRIPTION
Summary
========
* fixed autogen
* fixed template
* Closes: macaroni-os/mark-issues#132

Test Plan
========
* Doit
```
INFO     Autogen: dev-python/pefile (latest)
INFO     Autogen: sys-apps/fwupd (latest)
INFO     Autogen: sys-apps/fwupd-efi (latest)
INFO     Created: ../../dev-python/pefile/pefile-2024.8.26.ebuild
INFO     Created: fwupd-1.9.24.ebuild
INFO     Download from https://github.com/fwupd/fwupd-efi/tarball/03545b505ac821c967e0868be22aa9a55e77981d verified as valid tar.gz archive.
INFO     Created: ../fwupd-efi/fwupd-efi-1.7.ebuild
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
Updating profiles at /etc/portage/make.profile/parent...
Sync successful and kits in alignment! :)
workstation-funmore-repo ~ # emerge -av sys-apps/fwupd

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild  N     ] sys-boot/gnu-efi-3.0.18::core-kit  USE="(-custom-cflags)" 164 KiB
[ebuild  N     ] dev-python/pefile-2024.8.26::core-hw-kit  PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8" 75 KiB
[ebuild  N     ] dev-libs/libjcat-0.2.1::core-kit  USE="gpg introspection man pkcs7 -gtk-doc -test -vala" 75 KiB
[ebuild  N     ] dev-libs/libxmlb-0.3.19:0/2::dev-kit  USE="introspection -doc -stemmer -test" 129 KiB
[ebuild  N     ] sys-libs/libsmbios-2.4.2::core-kit  USE="nls python -doc -graphviz -static-libs -test" PYTHON_SINGLE_TARGET="python3_9 -python3_10 -python3_7 -python3_8" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8" 653 KiB
[ebuild  N     ] sys-apps/fwupd-efi-1.7::core-hw-kit  44 KiB
[ebuild  N     ] sys-apps/fwupd-1.9.24::core-hw-kit  USE="dell elogind gnutls introspection man policykit sqlite uefi -amt -archive -bash-completion -bluetooth -fastboot -flashrom -gtk-doc -gusb -logitech -lzma -minimal -modemmanager -nvme -spi -synaptics -test -thunderbolt -tpm" PYTHON_SINGLE_TARGET="python3_9 -python3_10 -python3_7 -python3_8" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8" 5,464 KiB

Total: 7 packages (7 new), Size of downloads: 6,601 KiB

Would you like to merge these packages? [Yes/No]
>>> Verifying ebuild manifests
>>> Emerging (1 of 7) sys-boot/gnu-efi-3.0.18::core-kit
>>> Installing (1 of 7) sys-boot/gnu-efi-3.0.18::core-kit
>>> Emerging (2 of 7) dev-python/pefile-2024.8.26::core-hw-kit
>>> Installing (2 of 7) dev-python/pefile-2024.8.26::core-hw-kit
>>> Emerging (3 of 7) dev-libs/libjcat-0.2.1::core-kit
>>> Installing (3 of 7) dev-libs/libjcat-0.2.1::core-kit
>>> Emerging (4 of 7) dev-libs/libxmlb-0.3.19::dev-kit
>>> Installing (4 of 7) dev-libs/libxmlb-0.3.19::dev-kit
>>> Emerging (5 of 7) sys-libs/libsmbios-2.4.2::core-kit
>>> Installing (5 of 7) sys-libs/libsmbios-2.4.2::core-kit
>>> Emerging (6 of 7) sys-apps/fwupd-efi-1.7::core-hw-kit
>>> Installing (6 of 7) sys-apps/fwupd-efi-1.7::core-hw-kit
>>> Emerging (7 of 7) sys-apps/fwupd-1.9.24::core-hw-kit
>>> Installing (7 of 7) sys-apps/fwupd-1.9.24::core-hw-kit
>>> Recording sys-apps/fwupd in "world" favorites file...
>>> Jobs: 7 of 7 complete                           Load avg: 2.95, 1.14, 0.43
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.

```
* Running it
```
workstation-funmore-repo ~ # fwupdtool --version
Loading…                 [************************************** ]
compile   org.freedesktop.fwupd         1.9.24
compile   com.hughsie.libxmlb           0.3.19
compile   com.hughsie.libjcat           0.2.1
runtime   com.hughsie.libxmlb           0.3.19
runtime   com.hughsie.libjcat           0.2.1
runtime   org.kernel                    6.10.7_p1-debian-sources
runtime   org.freedesktop.fwupd         1.9.24