### PR TITLE
[net-kit] net-vpn/openconnect - Drop dependency from kernel

### DIFF
--- a/net-kit/curated/net-vpn/openconnect/openconnect-8.10.ebuild
+++ b/net-kit/curated/net-vpn/openconnect/openconnect-8.10.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 PYTHON_COMPAT=( python3+ )
 PYTHON_REQ_USE="xml"
 
-inherit linux-info python-any-r1
+inherit python-any-r1
 
 ARCHIVE_URI="ftp://ftp.infradead.org/pub/${PN}/${P}.tar.gz"
 KEYWORDS="amd64 arm arm64 ppc64 x86"
@@ -55,10 +55,6 @@ BDEPEND="
 "
 
 CONFIG_CHECK="~TUN"
-
-pkg_pretend() {
-	check_extra_config
-}
 
 pkg_setup() {
 	:


### PR DESCRIPTION
The existing linux-info eclass is used only to
check if the `tun` kernel driver is present.
We consider the `tun` kernel driver present by default and in our kernel configs.

We could eventually to add an `einfo` message about the needs of CONFIG_TUN in the future.

Closes: macaroni-os/mark-issues#60