### PR TITLE
dev-lang/R enable lapack by default

### DIFF
--- a/lang-kit/curated/dev-lang/R/templates/R.tmpl
+++ b/lang-kit/curated/dev-lang/R/templates/R.tmpl
@@ -15,8 +15,8 @@ SRC_URI="
 
 LICENSE="|| ( GPL-2 GPL-3 ) LGPL-2.1"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~hppa ~ia64 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="cairo doc icu java jpeg lapack lto minimal nls openmp perl png prefix profile readline static-libs test tiff tk X"
+KEYWORDS="*"
+IUSE="cairo doc icu java jpeg +lapack lto minimal nls openmp perl png prefix profile readline static-libs test tiff tk X"
 
 REQUIRED_USE="png? ( || ( cairo X ) )
 	jpeg? ( || ( cairo X ) )


### PR DESCRIPTION
Summary
========
* Enabled lapack use flag by default
* Closes: macaroni-os/mark-issues#133

![image](https://github.com/user-attachments/assets/ff3ff515-3b79-417b-8910-679430d60b88)
