### PR TITLE
dev-vcs/git

### DIFF
--- a/core-kit/curated/dev-vcs/git/autogen.py
+++ b/core-kit/curated/dev-vcs/git/autogen.py
@@ -5,7 +5,7 @@ import re
 
 async def generate(hub, **pkginfo):
 	kernel_org = "https://www.kernel.org/pub/software/scm/git"
-	html_data = await hub.pkgtools.fetch.get_page("https://git-scm.com/download/linux")
+	html_data = await hub.pkgtools.fetch.get_page("https://git-scm.com/downloads/linux")
 	latest = re.search(f'<a href="{kernel_org}/git-([0-9.]*)\.tar.gz', html_data)
 	version = latest.group(1)
 	src_artifact = hub.pkgtools.ebuild.Artifact(url=f"{kernel_org}/git-{version}.tar.xz")


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#135
```
 ╰ $ doit
INFO     Autogen: dev-vcs/git (latest)                                                                                                                                                                                                                                                                              
INFO     Download from https://www.kernel.org/pub/software/scm/git/git-manpages-2.46.2.tar.xz verified as valid tar.xz archive.                                                                                                                                                                                     
INFO     Download from https://www.kernel.org/pub/software/scm/git/git-2.46.2.tar.xz verified as valid tar.xz archive.                                                                                                                                                                                              
INFO     Created: git/git-2.46.2.ebuild     ```