### PR TITLE
mail-client/thunderbird-bin

### DIFF
--- a/net-kit/curated/mail-client/thunderbird-bin/autogen.py
+++ b/net-kit/curated/mail-client/thunderbird-bin/autogen.py
@@ -42,7 +42,7 @@ async def generate(hub, **pkginfo):
 	lang_data = await get_lang_artifacts(hub, version)
 	ebuild = hub.pkgtools.ebuild.BreezyBuild(
 		**pkginfo,
-		version=version,
+		version=re.sub('esr','', version),
 		lang_codes=" ".join(sorted(lang_data["lang_codes"])),
 		artifacts=[get_artifact(hub, version, "amd64"), get_artifact(hub, version, "x86"), *lang_data["artifacts"]],
 	)

--- a/net-kit/curated/mail-client/thunderbird-bin/templates/thunderbird-bin.tmpl
+++ b/net-kit/curated/mail-client/thunderbird-bin/templates/thunderbird-bin.tmpl
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-MOZ_ESR=""
+MOZ_ESR=yes
 MOZ_LANGS=( {{lang_codes}} )
 
 # Convert the ebuild version to the upstream mozilla version, used by
@@ -10,8 +10,8 @@ MOZ_PN="${PN/-bin}"
 MOZ_PV="${PV/_beta/b}"
 MOZ_PV="${MOZ_PV/_rc/rc}"
 
-if [[ ${MOZ_ESR} == 1 ]]; then
-	# ESR releases have slightly version numbers
+if [[ -n ${MOZ_ESR} ]] ; then
+	# ESR releases have slightly different version numbers
 	MOZ_PV="${MOZ_PV}esr"
 fi
 
@@ -22,9 +22,10 @@ MOZ_HTTP_URI="https://archive.mozilla.org/pub/${MOZ_PN}/releases"
 inherit eutils multilib pax-utils xdg-utils nsplugins mozlinguas-v2
 
 DESCRIPTION="Thunderbird Mail Client"
+
 SRC_URI="${SRC_URI}
-	amd64? ( ${MOZ_HTTP_URI}/${MOZ_PV}/linux-x86_64/en-US/${MOZ_P}.tar.bz2 -> ${PN}_x86_64-${PV}.tar.bz2 )
-	x86? ( ${MOZ_HTTP_URI}/${MOZ_PV}/linux-i686/en-US/${MOZ_P}.tar.bz2 -> ${PN}_i686-${PV}.tar.bz2 )"
+	amd64? ( ${MOZ_HTTP_URI}/${MOZ_PV}/linux-x86_64/en-US/${MOZ_P}.tar.bz2 -> ${PN}_x86_64-${MOZ_PV}.tar.bz2 )
+	x86? ( ${MOZ_HTTP_URI}/${MOZ_PV}/linux-i686/en-US/${MOZ_P}.tar.bz2 -> ${PN}_i686-${MOZ_PV}.tar.bz2 )"
 
 HOMEPAGE="https://www.thunderbird.net/"
 RESTRICT="strip"


### PR DESCRIPTION
Summary
========
* removed esr from ebuild name, as portage reports invalid ebuild name
* Closes: macaroni-os/mark-issues#125

Test Plan
========
* Doit
```
 ╰ $ doit
INFO     Autogen: mail-client/thunderbird-bin (latest)
INFO     Download from https://archive.mozilla.org/pub/thunderbird/releases/128.2.3esr/linux-i686/en-US/thunderbird-128.2.3esr.tar.bz2 verified as valid tar.bz2 archive.
INFO     Download from https://archive.mozilla.org/pub/thunderbird/releases/128.2.3esr/linux-x86_64/en-US/thunderbird-128.2.3esr.tar.bz2 verified as valid tar.bz2 archive.
INFO     Created: thunderbird-bin-128.2.3.ebuild
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
workstation-mark-repo ~ # emerge -av mail-client/thunderbird-bin

These are the packages that would be merged, in order:

Calculating dependencies -
Invalid ebuild name: /var/git/meta-repo/kits/net-kit/mail-client/thunderbird-bin/thunderbird-bin-128.2.3esr.ebuild
... done!
[ebuild  N     ] mail-client/thunderbird-bin-128.2.3::overlay  USE="crashreporter ffmpeg pulseaudio (-selinux)" L10N="-af -ar -ast -be -bg -br -ca -cak -cs -cy -da -de -dsb -el -en-CA -en-GB -es-AR -es-ES -es-MX -et -eu -fi -fr -fy -ga -gd -gl -he -hr -hsb -hu -hy -id -is -it -ja -ka -kab -kk -ko -lt -lv -ms -nb -nl -nn -pa -pl -pt-BR -pt-PT -rm -ro -ru -sk -sl -sq -sr -sv -th -tr -uk -uz -vi -zh-CN -zh-TW" 0 KiB

Total: 1 package (1 new), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No]
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) mail-client/thunderbird-bin-128.2.3::overlay
>>> Installing (1 of 1) mail-client/thunderbird-bin-128.2.3::overlay
>>> Recording mail-client/thunderbird-bin in "world" favorites file...
>>> Jobs: 1 of 1 complete                           Load avg: 0.45, 0.23, 0.13
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
workstation-mark-repo ~ #
```
* Running it
```
workstation-mark-repo ~ # thunderbird-bin -version
Thunderbird 128.2.3esr
workstation-mark-repo ~ #
```
![image](https://github.com/user-attachments/assets/4fe04d60-a10e-4df6-894e-31f5b8399931)
