### PR TITLE
=dev-python/markupsafe-3.0.0

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -2103,7 +2103,7 @@ dev_python_simplified_rule:
     - markupsafe:
         compat: 1.1.1
         blocker: '!<dev-python/markupsafe-2.0.0'
-        pypi_name: MarkupSafe
+        pypi_name: markupsafe
         desc: Implements a XML/HTML/XHTML Markup safe string for Python
         homepage: https://pypi.org/project/MarkupSafe
         license: BSD


### PR DESCRIPTION
Summary
========
* pipy name chnaged
* Closes: macaroni-os/mark-issues#152

Test Plan
========
* Doit
```
 ╰ $ doit --pkg markupsafe
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                                                                                                                            
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                                                                                                                            
INFO     Autogen: dev-python/markupsafe (latest)                                                                                                                                                                                                                                                                    
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                                                                                                                            
INFO     Download from https://files.pythonhosted.org/packages/5c/84/3f683b24fcffa08c5b7ef3fb8a845661057dd39c321c1ae16fa37a3eb35b/markupsafe-3.0.0.tar.gz verified as valid tar.gz archive.                                                                                                                         
INFO     Created: markupsafe/markupsafe-3.0.0.ebuild                                                                                                                                                                                                                                                                
INFO     Download from https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz verified as valid tar.gz archive.                                                                                                                         
INFO     Created: markupsafe-compat/markupsafe-compat-1.1.1.ebuild    
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
HEAD is now at 981cbf3 Autogenerated tree updates.
Already up to date.
Updating /etc/portage/repos.conf...
Updating profiles at /etc/portage/make.profile/parent...
Updating non-funtoo repositories...
Sync successful and kits in alignment! :)

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] dev-python/markupsafe-3.0.0::python-modules-kit [2.1.5::python-modules-kit] PYTHON_TARGETS="python3_9 -python2_7 -python3_10 -python3_7 -python3_8" 0 KiB

Total: 1 package (1 upgrade), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-python/markupsafe-3.0.0::python-modules-kit
>>> Installing (1 of 1) dev-python/markupsafe-3.0.0::python-modules-kit
>>> Jobs: 1 of 1 complete                           Load avg: 2.18, 1.84, 1.64
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
 * After world updates, it is important to remove obsolete packages with
 * emerge --depclean. Refer to `man emerge` for more information.

 * Always study the list of packages to be cleaned for any obvious
 * mistakes. Packages that are part of the world set will always
 * be kept.  They can be manually added to this set with
 * `emerge --noreplace <atom>`.  Packages that are listed in
 * package.provided (see portage(5)) will be removed by
 * depclean, even if they are part of the world set.
 * 
 * As a safety measure, depclean will not remove any packages
 * unless *all* required dependencies have been resolved.  As a
 * consequence of this, it often becomes necessary to run 
 * `emerge --update --newuse --deep @world` prior to depclean.


```