### PR TITLE
[python-modules-kit] dev-python/zope-interface review

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -2473,8 +2473,7 @@ dev_python_autogen_rule:
     - zope-exceptions
     - zope-hookable:
         version: "5.2"
-    - zope-interface:
-        version: "6.3"
+    - zope-interface
     - zope-i18nmessageid:
         version: "5.0.1"
     - zope-location


### PR DESCRIPTION
Using last available release.

Closes: macaroni-os/mark-issues#85