### PR TITLE
[core-kit] sys-boot/linux review

### DIFF
--- a/core-kit/curated/sys-boot/syslinux/files/6.04_pre1/0005-stddef_addwchar_t.patch
+++ b/core-kit/curated/sys-boot/syslinux/files/6.04_pre1/0005-stddef_addwchar_t.patch
@@ -1,0 +1,59 @@
+From 063dac55c45d0264671c3463e824ab659e5cbb87 Mon Sep 17 00:00:00 2001
+From: Julien Olivain <ju.o@free.fr>
+Date: Tue, 27 Feb 2024 21:09:15 +0100
+Subject: [PATCH] stddef.h: add wchar_t type definition
+
+Syslinux fail to build with gnu-efi >= 3.0.16 with error:
+
+    In file included from /host/i686-buildroot-linux-gnu/sysroot/usr/include/efi/efi.h:44,
+                     from /build/syslinux-6.03/efi/efi.h:23,
+                     from /build/syslinux-6.03/efi/adv.h:4,
+                     from /build/syslinux-6.03/efi/adv.c:29:
+    /host/i686-buildroot-linux-gnu/sysroot/usr/include/efi/ia32/efibind.h:90:9: error: unknown type name 'wchar_t'
+     typedef wchar_t CHAR16;
+             ^~~~~~~
+
+This is because gnu-efi started to use the "wchar_t" type from the
+toolchain's <stddef.h> header, in commit [1]. Before this commit,
+gnu-efi was defining the type as "short".
+
+Syslinux is including its own minimal stddef.h file, which masks the
+one provided by the toolchain. See [2]. This file does not have a type
+definition for "wchar_t".
+
+Finally, the POSIX <stddef.h> header is supposed to provide this
+"wchar_t" type definition. See [3].
+
+This commit fixes the issue by adding the "wchar_t" type definition in
+the com32/include/stddef.h header. Since Syslinux has "-fshort-wchar"
+in its CFLAGS (see [4]), "wchar_t" is simply defined as "short". This
+also follow the previous gnu-efi < 3.0.16 behavior.
+
+This issue was seen in Buildroot Linux, in [5].
+
+[1] https://sourceforge.net/p/gnu-efi/code/ci/189200d0b0f6fff473d302880d9569f45d4d8c4d
+[2] https://repo.or.cz/syslinux.git/blob/refs/tags/syslinux-6.03:/com32/include/stddef.h
+[3] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stddef.h.html
+[4] https://repo.or.cz/syslinux.git/blob/refs/tags/syslinux-6.03:/mk/efi.mk#l27
+[5] https://lists.buildroot.org/pipermail/buildroot/2024-February/685971.html
+
+Upstream: Proposed: https://www.syslinux.org/archives/2024-February/026903.html
+Signed-off-by: Julien Olivain <ju.o@free.fr>
+---
+ com32/include/stddef.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/com32/include/stddef.h b/com32/include/stddef.h
+index f52d62f3..437b11f2 100644
+--- a/com32/include/stddef.h
++++ b/com32/include/stddef.h
+@@ -29,4 +29,6 @@
+  */
+ #define container_of(p, c, m) ((c *)((char *)(p) - offsetof(c,m)))
+ 
++typedef short wchar_t;
++
+ #endif /* _STDDEF_H */
+-- 
+2.44.0
+

--- a/core-kit/curated/sys-boot/syslinux/syslinux-6.04_pre3.ebuild
+++ b/core-kit/curated/sys-boot/syslinux/syslinux-6.04_pre3.ebuild
@@ -21,7 +21,10 @@ RESTRICT="test"
 BDEPEND="
 	dev-lang/perl
 	bios? (
-		app-arch/upx
+		|| (
+			app-arch/upx
+			app-arch/upx-bin
+		)
 		app-text/asciidoc
 		dev-lang/nasm
 	)


### PR DESCRIPTION
* support upx-bin package in alternative of upx
* fix compilation issues after >=gnu-efi-3.0.16

Closes: macaroni-os/mark-issues#161