### PR TITLE
 app-editors/vscode-bin with @geaaru and nemotron:latest ;) 

### DIFF
--- a/editors-kit/curated/app-editors/vscode-bin/autogen.py
+++ b/editors-kit/curated/app-editors/vscode-bin/autogen.py
@@ -1,23 +1,21 @@
 #!/usr/bin/env python3
 
-import re
 from pathlib import Path
 
+from sphinx.util import requests
 
-async def generate_for(hub, pkg_name, release_channel, stable, version, **pkginfo):
 
-    # get version from .deb file:
-    # url_template = f"https://code.visualstudio.com/sha/download?build={release_channel}&os="
-    # redirect_url = await hub.pkgtools.fetch.get_url_from_redirect(url_template + "linux-deb-x64")
-    # deb_filename = redirect_url.split("/")[-1]
-    # filename_pattern = re.compile(f"^{pkg_name}_([\d.]+)-(\d+)_amd64\.deb$")
-    # version, revision = filename_pattern.match(deb_filename).groups()
-    # if not stable:
-    #     version += "_p" + revision
-    # src_url = await hub.pkgtools.fetch.get_url_from_redirect(url_template + "linux-x64")
+async def generate_for(hub, pkg_name, release_channel, stable, **pkginfo):
+
+    url = "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64"
+    headers = {
+        'User-Agent': 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0',
+        'Connection' : 'keep-alive',
+    }
+    response = requests.get(url, headers=headers)
+    version = extract_version_from_header(response.headers)
 
     src_url = f"https://update.code.visualstudio.com/{version}/linux-x64/{release_channel}"
-    # get .tar.gz, but use version we got from deb:
 
     artifact = hub.pkgtools.ebuild.Artifact(url=src_url, final_name=f"{pkginfo['name']}-{version}.tar.gz")
     await artifact.fetch()
@@ -40,9 +38,43 @@ async def generate_for(hub, pkg_name, release_channel, stable, version, **pkginf
         src_path_name=src_path.name,
     )
     ebuild.push()
+import re
 
+def extract_version_from_header(response_headers):
+    """
+    Extracts version from filename in Content-Disposition header.
+
+    Parameters:
+    - response_headers: Dictionary containing HTTP response headers.
+
+    Returns:
+    - version (str) if found, otherwise None.
+    """
+    # Step 1 & 2: Parse Content-Disposition to extract the filename
+    content_disposition = response_headers.get('Content-Disposition')
+    if not content_disposition:
+        return None
+
+    # Regular expression to match the filename with or without UTF-8 declaration
+    filename_pattern = r"filename(?:\*=UTF-8''|)=([^;]+)"
+    match = re.search(filename_pattern, content_disposition)
+
+    if match:
+        filename = match.group(1)
+    else:
+        return None  # No filename found
+
+    # Step 3: Extract version from the filename
+    # Assuming version format is x.x.x (adjust pattern as needed for other formats)
+    version_pattern = r"(\d+(?:\.\d+)*)"
+    version_match = re.search(version_pattern, filename)
+
+    if version_match:
+        return version_match.group(1)  # Return the matched version
+    else:
+        return None  # No version found in the filename
 
 async def generate(hub, **pkginfo):
-    await generate_for(hub, "code", "stable", True, "1.94.2", **pkginfo)
+    await generate_for(hub, "code", "stable", True, **pkginfo)
 
 # vim: ts=4 sw=4 noet

--- a/editors-kit/curated/app-editors/vscode-bin/autogen.py
+++ b/editors-kit/curated/app-editors/vscode-bin/autogen.py
@@ -4,19 +4,19 @@ import re
 from pathlib import Path
 
 
-async def generate_for(hub, pkg_name, release_channel, stable, **pkginfo):
+async def generate_for(hub, pkg_name, release_channel, stable, version, **pkginfo):
 
     # get version from .deb file:
+    # url_template = f"https://code.visualstudio.com/sha/download?build={release_channel}&os="
+    # redirect_url = await hub.pkgtools.fetch.get_url_from_redirect(url_template + "linux-deb-x64")
+    # deb_filename = redirect_url.split("/")[-1]
+    # filename_pattern = re.compile(f"^{pkg_name}_([\d.]+)-(\d+)_amd64\.deb$")
+    # version, revision = filename_pattern.match(deb_filename).groups()
+    # if not stable:
+    #     version += "_p" + revision
+    # src_url = await hub.pkgtools.fetch.get_url_from_redirect(url_template + "linux-x64")
 
-    url_template = f"https://code.visualstudio.com/sha/download?build={release_channel}&os="
-    redirect_url = await hub.pkgtools.fetch.get_url_from_redirect(url_template + "linux-deb-x64")
-    deb_filename = redirect_url.split("/")[-1]
-    filename_pattern = re.compile(f"^{pkg_name}_([\d.]+)-(\d+)_amd64\.deb$")
-    version, revision = filename_pattern.match(deb_filename).groups()
-    if not stable:
-        version += "_p" + revision
-    src_url = await hub.pkgtools.fetch.get_url_from_redirect(url_template + "linux-x64")
-
+    src_url = f"https://update.code.visualstudio.com/{version}/linux-x64/{release_channel}"
     # get .tar.gz, but use version we got from deb:
 
     artifact = hub.pkgtools.ebuild.Artifact(url=src_url, final_name=f"{pkginfo['name']}-{version}.tar.gz")
@@ -43,6 +43,6 @@ async def generate_for(hub, pkg_name, release_channel, stable, **pkginfo):
 
 
 async def generate(hub, **pkginfo):
-    await generate_for(hub, "code", "stable", True, **pkginfo)
+    await generate_for(hub, "code", "stable", True, "1.94.2", **pkginfo)
 
 # vim: ts=4 sw=4 noet


### PR DESCRIPTION
```
 ╰ $ doit
INFO     Autogen: app-editors/vscode-bin (latest)                                                                                                                                                                                                                                                                   
INFO     Download from https://update.code.visualstudio.com/1.94.2/linux-x64/stable verified as valid tar.gz archive.                                                                                                                                                                                               
INFO     Created: vscode-bin-1.94.2.ebuild          ```
