### PR TITLE
[core-hw-kit] sys-firmware/sgabios is missing on mark testing

### DIFF
--- a/core-hw-kit/mark/packages.yaml
+++ b/core-hw-kit/mark/packages.yaml
@@ -4,8 +4,6 @@ packages:
     - sys-firmware/seabios
     - sys-firmware/edk2-ovmf
     - sys-power/iasl
-    - sys-firmware/ipxe
-    - sys-firmware/sgabios
 - gentoo-staging:
   - net-wireless/portapack-firmware
   - net-wireless/bladerf-firmware

--- a/core-hw-kit/mark/sys-firmware/sgabios/autogen.yaml
+++ b/core-hw-kit/mark/sys-firmware/sgabios/autogen.yaml
@@ -1,0 +1,9 @@
+sgabios:
+  generator: github-1
+  packages:
+    - sgabios:
+        version: 0.1_pre10
+        github:
+          user: qemu
+          query: snapshot
+          snapshot: 72f39d48bedf044e202fd51fecf3e2218fc2ae66

--- a/core-hw-kit/mark/sys-firmware/sgabios/templates/sgabios.tmpl
+++ b/core-hw-kit/mark/sys-firmware/sgabios/templates/sgabios.tmpl
@@ -1,0 +1,39 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="serial graphics adapter bios option rom for x86"
+HOMEPAGE="https://code.google.com/p/sgabios/ https://github.com/qemu/sgabios"
+SRC_URI="{{ src_uri }}"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="*"
+IUSE=""
+
+post_src_unpack() {
+	mv ${PN}-* ${S}
+}
+
+src_compile() {
+	tc-ld-disable-gold
+	tc-export_build_env BUILD_CC
+	emake -j1 \
+		BUILD_CC="${BUILD_CC}" \
+		BUILD_CFLAGS="${BUILD_CFLAGS}" \
+		BUILD_LDFLAGS="${BUILD_LDFLAGS}" \
+		BUILD_CPPFLAGS="${BUILD_CPPFLAGS}" \
+		CC="$(tc-getCC)" \
+		LD="$(tc-getLD)" \
+		AR="$(tc-getAR)" \
+		OBJCOPY="$(tc-getOBJCOPY)"
+}
+
+src_install() {
+	insinto /usr/share/sgabios
+	doins sgabios.bin
+}
+
+# vim: filetype=ebuild

--- a/core-kit/curated/app-emulation/qemu/qemu-7.1.0.ebuild
+++ b/core-kit/curated/app-emulation/qemu/qemu-7.1.0.ebuild
@@ -204,21 +204,23 @@ X86_FIRMWARE_DEPEND="
 	pin-upstream-blobs? (
 		~sys-firmware/edk2-ovmf-bin-${EDK2_OVMF_VERSION}
 		~sys-firmware/seabios-bin-${SEABIOS_VERSION}
-		~sys-firmware/sgabios-0.1_pre10[binary]
 	)
 	!pin-upstream-blobs? (
 		>=sys-firmware/edk2-ovmf-${EDK2_OVMF_VERSION}
-		>=sys-firmware/seabios-${SEABIOS_VERSION}[seavgabios]
+		|| (
+			>=sys-firmware/seabios-${SEABIOS_VERSION}[seavgabios]
 			>=sys-firmware/seabios-bin-${SEABIOS_VERSION}
-		sys-firmware/sgabios
+		)
 	)"
 PPC_FIRMWARE_DEPEND="
 	pin-upstream-blobs? (
 		~sys-firmware/seabios-bin-${SEABIOS_VERSION}
 	)
 	!pin-upstream-blobs? (
+		|| (
 			>=sys-firmware/seabios-${SEABIOS_VERSION}[seavgabios]
 			>=sys-firmware/seabios-bin-${SEABIOS_VERSION}
+		)
 	)
 "
 
@@ -249,6 +251,7 @@ CDEPEND="
 "
 DEPEND="${CDEPEND}
 	sys-firmware/ipxe[qemu]
+	sys-firmware/sgabios
 	kernel_linux? ( >=sys-kernel/linux-headers-2.6.35 )
 	static? (
 		${ALL_DEPEND}


### PR DESCRIPTION
Bugs: macaroni-os/mark-issues#163

```
 $ doit --release mark
INFO     Autogen: sys-firmware/sgabios-0.1_pre10                                                                                                                                                      
INFO     Created: sgabios-0.1_pre10.ebuild                                      
```


```
>>> Installing (1 of 1) sys-firmware/sgabios-0.1_pre10::core-hw-kit

>>> Recording sys-firmware/sgabios in "world" favorites file...
>>> Auto-cleaning packages...
```