### PR TITLE
[python-modules-kit] dev-python/docker-py review autogen

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -204,7 +204,6 @@ github_stuff:
     python_compat: python3+
   packages:
     - docker-py:
-        version: '5.0.3'
         github:
           query: releases
           user: docker
@@ -224,8 +223,7 @@ github_stuff:
           }
           src_prepare() {
             default
-            # localhost has a better chance of being in /etc/hosts
-            sed -i -e 's:socket[.]gethostname():"localhost":' tests/unit/api_test.py || die
+            sed -i -e 's|^license =.*|license = {text = "Apache-2.0"}|g' pyproject.toml
             distutils-r1_src_prepare
           }
     - parse_type:

--- a/python-modules-kit/packages.yaml
+++ b/python-modules-kit/packages.yaml
@@ -559,7 +559,6 @@ packages:
   - dev-python/pyocr
   - dev-python/patsy
   - dev-python/girder-client
-  - dev-python/docker-py
   - dev-python/expects
   - dev-python/xstatic-jquery
   - dev-python/nose_fixes


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#102

Run `doit`:
```
$ doit --release mark --pkg docker-py
INFO     Autogen: dev-python/docker-py (latest)                                                                                                                                                                     
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                            
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                            
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                            
INFO     Created: docker-py/docker-py-7.1.0.ebuild                                   
```

Test emerge:
```
 # emerge docker-py  -j
Calculating dependencies... done!
>>> Verifying ebuild manifests
>>> Emerging (1 of 2) dev-python/websocket-client-0.48.0::python-modules-kit
>>> Installing (1 of 2) dev-python/websocket-client-0.48.0::python-modules-kit
>>> Emerging (2 of 2) dev-python/docker-py-7.1.0::python-modules-kit
>>> Installing (2 of 2) dev-python/docker-py-7.1.0::python-modules-kit
>>> Recording dev-python/docker-py in "world" favorites file...
>>> Jobs: 2 of 2 complete                           Load avg: 0.66, 0.20, 0.07
>>> Auto-cleaning packages...
```