### PR TITLE
[core-server-kit] Add app-backup/backrest autogen

### DIFF
--- a/core-server-kit/mark/app-backup/backrest/autogen.yaml
+++ b/core-server-kit/mark/app-backup/backrest/autogen.yaml
@@ -1,0 +1,10 @@
+backrest:
+  generator: github-1
+  packages:
+    - backrest:
+        extensions:
+          - golang
+        github:
+          user: garethgeorge
+          repo: backrest
+          query: releases

--- a/core-server-kit/mark/app-backup/backrest/files/backrest.confd
+++ b/core-server-kit/mark/app-backup/backrest/files/backrest.confd
@@ -1,0 +1,18 @@
+# Configuration file for Backrest
+BACKREST_PORT="127.0.0.1:9898"
+
+# Define the path of the restic tool.
+# If not present or not define backrest try to
+# download the restic binary automatically.
+BACKREST_RESTIC_COMMAND=/usr/bin/restic
+
+BACKREST_DATA=/var/lib/backrest/data
+
+# Override the path of the backrest config file
+# BACKREST_CONFIG=
+
+# Define additional command line args.
+# backrest_args=
+
+# backrest_user=backrest
+# backrest_group=backrest

--- a/core-server-kit/mark/app-backup/backrest/files/backrest.initd
+++ b/core-server-kit/mark/app-backup/backrest/files/backrest.initd
@@ -1,0 +1,44 @@
+#!/sbin/openrc-run
+# Distributed under the terms of the GNU General Public License v2
+
+name="backrest daemon"
+description="Restic WebUI Orchestrator"
+command=/usr/bin/backrest
+command_args="${backrest_args}"
+buser=${backrest_user:-backrest}
+bgroup=${backrest_group:-backrest}
+
+if [ -n "${BACKREST_PORT}" ] ; then
+	start_stop_daemon_args="${start_stop_daemon_args} \
+		--env BACKREST_PORT=${BACKREST_PORT}"
+fi
+if [ -n "${BACKREST_RESTIC_COMMAND}" ] ; then
+	start_stop_daemon_args="${start_stop_daemon_args} \
+		--env BACKREST_RESTIC_COMMAND=${BACKREST_RESTIC_COMMAND}"
+fi
+if [ -n "${BACKREST_DATA}" ] ; then
+	start_stop_daemon_args="${start_stop_daemon_args} \
+		--env BACKREST_DATA=${BACKREST_DATA}"
+fi
+if [ -n "${BACKREST_CONFIG}" ] ; then
+	start_stop_daemon_args="${start_stop_daemon_args} \
+		--env BACKREST_CONFIG=${BACKREST_CONFIG}"
+fi
+
+depend() {
+	need net
+}
+
+start() {
+	ebegin "Starting backrest service"
+	start-stop-daemon --start \
+		--user ${buser} \
+		--group ${bgroup} \
+		--pidfile ${PIDFILE} \
+		--exec ${command} \
+		--background \
+		${start_stop_daemon_args} \
+		--make-pidfile
+
+	eend ${?}
+}

--- a/core-server-kit/mark/app-backup/backrest/files/backrest.service
+++ b/core-server-kit/mark/app-backup/backrest/files/backrest.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Backrest Service
+After=network.target
+
+[Service]
+Type=simple
+User=backrest
+Group=backrest
+EnvironmentFile=/etc/conf.d/backrest
+ExecStart=/usr/bin/backrest
+
+[Install]
+WantedBy=multi-user.target

--- a/core-server-kit/mark/app-backup/backrest/templates/backrest.tmpl
+++ b/core-server-kit/mark/app-backup/backrest/templates/backrest.tmpl
@@ -1,0 +1,60 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit go-module systemd user
+
+EGO_SKIP_TIDY=1
+EGO_SUM=(
+{{gosum}})
+
+DESCRIPTION="Backrest is a web UI and orchestrator for restic backup"
+HOMEPAGE="https://github.com/garethgeorge/backrest"
+SRC_URI="{{ src_uri }}"
+# Uses npm to download packages
+RESTRICT="network-sandbox"
+LICENSE="GPL-3.0"
+SLOT="0"
+KEYWORDS="*"
+IUSE="systemd"
+
+RDEPEND="app-backup/restic"
+DEPEND="${RDEPEND}
+	net-libs/nodejs
+"
+
+pkg_setup() {
+	ebegin "Ensuring backrest group and user exist"
+	enewgroup backrest
+	enewuser backrest -1 -1 /var/lib/backrest backrest
+	eend $?
+}
+
+post_src_unpack() {
+	mv ${WORKDIR}/garethgeorge-backrest-* ${S}
+}
+
+src_compile() {
+	GOOS=linux BACKREST_BUILD_VERSION={{version}} \
+		go generate ./...
+
+	CGO_ENABLED=0 \
+		go build \
+		-asmflags "-trimpath=${S}" \
+		-gcflags "-trimpath=${S}" \
+		-o backrest ./cmd/backrest
+}
+
+src_install() {
+	dobin backrest
+	diropts -m0750 -o backrest -g backrest
+	dodir /var/lib/backrest/
+	fowners backrest:backrest /var/lib/backrest
+	keepdir /var/lib/backrest
+	if use systemd ; then
+		systemd_newunit "${FILESDIR}"/backrest.service backrest.service || die
+	else
+		newinitd "${FILESDIR}"/backrest.initd backrest
+	fi
+	newconfd "${FILESDIR}"/backrest.confd backrest
+}


### PR DESCRIPTION
Note: ATM to compile the webui you need <nodejs-22. I hope that this will be fixed soon.

Closes: macaroni-os/mark-issues#168