### PR TITLE
dev-python/mako pypi name

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -562,7 +562,7 @@ dev_python_compat_rule:
         blocker: "!<dev-python/mako-1.2.0-r1"
         revision:
           1.2.0: 1
-        pypi_name: Mako
+        pypi_name: mako
         inherit:
           - eutils
         python_compat: python2+


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#170

~ # emerge -av mako


```
These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] dev-python/mako-1.3.6::python-modules-kit [1.3.5::python-modules-kit] PYTHON_TARGETS="python3_9 -python2_7 -python3_10 -python3_7 -python3_8" 0 KiB

Total: 1 package (1 upgrade), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-python/mako-1.3.6::python-modules-kit
>>> Installing (1 of 1) dev-python/mako-1.3.6::python-modules-kit
>>> Recording dev-python/mako in "world" favorites file...
>>> Jobs: 1 of 1 complete                           Load avg: 0.92, 0.80, 1.09

 * Messages for package dev-python/mako-1.3.6:

 * Optional dependencies:
 *   dev-python/beaker for caching support
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
```