### PR TITLE
=dev-ruby/json-2.7.4 fix avoiding setting gem

### DIFF
--- a/ruby-kit/next/dev-ruby/templates/json.tmpl
+++ b/ruby-kit/next/dev-ruby/templates/json.tmpl
@@ -49,7 +49,7 @@ all_ruby_prepare() {
 		-e '/^unless/,/^end/ s:^:#:' ext/json/ext/*/extconf.rb || die
 
 	# Avoid setting gem since it will not be available yet when installing
-	sed -i -e '/gem/ s:^:#:' tests/test_helper.rb || die
+	sed -i -e '/gem/ s:^:#:' test/json/test_helper.rb || die
 }
 
 #each_ruby_compile() {


### PR DESCRIPTION
Summary
========
*
* Closes: macaroni-os/mark-issues#174

```
~ # emerge -av dev-ruby/json

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] dev-ruby/json-2.7.4:2::ruby-kit [2.7.2:2::ruby-kit] USE="-doc -test" RUBY_TARGETS="ruby31 -ruby27 -ruby30 -ruby32" 0 KiB

Total: 1 package (1 upgrade), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No]
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-ruby/json-2.7.4::ruby-kit
>>> Installing (1 of 1) dev-ruby/json-2.7.4::ruby-kit
>>> Recording dev-ruby/json in "world" favorites file...
>>> Jobs: 1 of 1 complete                           Load avg: 3.46, 2.42, 1.25
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
``