### PR TITLE
[core-hw-kit] sys-power/cpupower - review template

### DIFF
--- a/core-hw-kit/curated/sys-power/cpupower/templates/cpupower.tmpl
+++ b/core-hw-kit/curated/sys-power/cpupower/templates/cpupower.tmpl
@@ -30,6 +30,7 @@ src_configure() {
 src_compile() {
 	myemakeargs=(
 		VERSION=${PV}
+		libdir="/usr/$(get_libdir)"
 	)
 
 	cd tools/power/cpupower || die
@@ -48,3 +49,5 @@ src_install() {
 	systemd_dounit "${FILESDIR}"/cpupower-frequency-set.service
 	systemd_install_serviced "${FILESDIR}"/cpupower-frequency-set.service.conf
 }
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Fix installation of the libraries in the
right path.

emerge:

```
   /usr/sbin/cpufreq-bench
   /usr/bin/cpupower
   /usr/lib64/libcpupower.so.0.0.1

>>> Installing (1 of 1) sys-power/cpupower-6.11.5::core-hw-kit

>>> Recording sys-power/cpupower in "world" favorites file...
>>> Auto-cleaning packages...

```

Closes: macaroni-os/mark-issues#156