### PR TITLE
[core-kit] [feature] Add `intel64-tremont` subarch (`mark-testing`)

### DIFF
--- a/core-kit/curated/profiles/funtoo/1.0/linux-gnu/arch/x86-64bit/subarch/intel64-tremont/make.defaults
+++ b/core-kit/curated/profiles/funtoo/1.0/linux-gnu/arch/x86-64bit/subarch/intel64-tremont/make.defaults
@@ -1,0 +1,6 @@
+CFLAGS="-march=tremont -O2 -pipe"
+CXXFLAGS="${CFLAGS}"
+FFLAGS="${CFLAGS}"
+FCFLAGS="${CFLAGS}"
+
+CPU_FLAGS_X86="aes mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 ssse3"


### PR DESCRIPTION
Adds new subarch for CPUs like `Intel(R) Celeron(R) J6412 @ 2.00GHz` (as reported by `/proc/cpuinfo`).

The flags were obtained from https://github.com/projg2/cpuid2cpuflags.

`CPU_FLAGS_X86="aes mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 ssse3"`

Use it in the usual way, with `ego profile subarch intel64-tremont`.