### PR TITLE
[python-modules-kit] dev-python/llfuse dropped

### DIFF
--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -168,29 +168,6 @@ pypi_compat_rule:
 
             py.test -v _test/test_*.py || die
           }
-    - llfuse:
-        desc: Python bindings for the low level FUSE API
-        iuse: doc examples test
-        pydeps:
-          use:test:
-            - pytest
-          py:all:build:
-            - setuptools
-        rdepend: |
-            sys-fs/fuse
-        depend: |
-            sys-apps/attr
-            virtual/pkgconfig
-        body: |
-          python_test() {
-            py.test -v || die "Tests failed under ${EPYTHON}"
-          }
-
-          python_install_all() {
-            use doc && local HTML_DOCS=( doc/html/. )
-            use examples && dodoc -r examples
-            distutils-r1_python_install_all
-          }
     - pyicu:
         pypi_name: PyICU
         python_compat: python3+

--- a/python-modules-kit/packages.yaml
+++ b/python-modules-kit/packages.yaml
@@ -520,7 +520,6 @@ packages:
   - dev-python/ipaddr
   - dev-python/cssselect
   - dev-python/pypam
-  - dev-python/llfuse
   - dev-python/coverage
   - dev-python/py2play
   - dev-python/shutilwhich


### PR DESCRIPTION
Package no more maintained.

Closes: macaroni-os/mark-issues#175