### PR TITLE
[games-kit] [bugfix] Update `zmusic` and correct `gzdoom` `DEPEND` (`next`)

### DIFF
--- a/games-kit/curated/autogen.yaml
+++ b/games-kit/curated/autogen.yaml
@@ -43,7 +43,7 @@ doom_github_rule:
         github:
           user: ZDoom
           repo: ZMusic
-          query: releases
+          query: tags
     - doomrunner:
         cat: games-util
         desc: Preset-oriented graphical launcher of various ported Doom engines (an alternative to ZDL)

--- a/games-kit/curated/templates/gzdoom.tmpl
+++ b/games-kit/curated/templates/gzdoom.tmpl
@@ -20,7 +20,7 @@ DEPEND="
 	media-libs/libvpx:=
 	media-libs/libwebp
 	media-libs/openal
-	media-libs/zmusic
+	>=media-libs/zmusic-1.1.14
 	sys-libs/zlib
 	gtk? ( x11-libs/gtk+:3 )"
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
With additional work to change the `DEPEND` for `gzdoom`, fixes macaroni-os/mark-issues#178 and macaroni-os/mark-issues#180.