### PR TITLE
[python-modules-kit] dev-python/motor fix DEPEND

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -1879,6 +1879,8 @@ dev_python_simplified_rule:
         rdepend: |
           !<dev-python/pymongo-4.1
         pydeps:
+          py:all:build:
+            - hatch-requirements-txt
           py:all:
             - pymongo >= 4.1
     - pyparsing:


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#182

doit:

```
$ doit --release mark --pkg motor                                                                                                                                                      
INFO     Autogen: dev-python/motor (latest)                                                                                                                                                                                                                                                                                             
INFO     Created: motor/motor-3.6.0.ebuild                                                                                                                                                       
```


Test:
```
>>> Installing (1 of 1) dev-python/motor-3.6.0::python-modules-kit
```

