### PR TITLE
=app-text/enchant-2.8.2

### DIFF
--- a/text-kit/curated/app-text/enchant/autogen.yaml
+++ b/text-kit/curated/app-text/enchant/autogen.yaml
@@ -3,9 +3,7 @@ enchant:
   packages:
     - enchant:
         github:
-          user: AbiWord
+          user: rrthomas
           repo: enchant
           query: releases
           tarball: "enchant-{version}.tar.gz"
-        revision:
-          '2.3.3': 1

--- a/text-kit/curated/app-text/enchant/templates/enchant.tmpl
+++ b/text-kit/curated/app-text/enchant/templates/enchant.tmpl
@@ -3,8 +3,8 @@
 EAPI=7
 
 DESCRIPTION="Spellchecker wrapping library"
-HOMEPAGE="https://abiword.github.io/enchant/"
-SRC_URI="{{ artifacts[0].src_uri }}"
+HOMEPAGE="https://github.com/rrthomas/enchant"
+SRC_URI="{{ src_uri }}"
 
 LICENSE="LGPL-2.1+"
 SLOT="2"


### PR DESCRIPTION
Summary
========
* AbiWord is going to personal care of Reuben Thomas so changing the repo. See See https://github.com/rrthomas/enchant/commit/d5346b19b294081d329d70bed0b4eccb09380f4d#diff-7ee66c4f1536ac84dc5bbff1b8312e2eef24b974b3e48a5c5c2bcfdf2eb8f3ceR4
* Closes: macaroni-os/mark-issues#/186

Test Plan
========
* Doit
```
 ╰ $ doit
INFO     Autogen: app-text/enchant (latest)                                                                                                                                                                                                                                                                         
INFO     Download from https://github.com/rrthomas/enchant/releases/download/v2.8.2/enchant-2.8.2.tar.gz verified as valid tar.gz archive.                                                                                                                                                                          
INFO     Created: enchant-2.8.2.ebuild   
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
~ # emerge -av app-text/enchant

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild   R    ] app-text/enchant-2.8.2:2::overlay [2.8.2:2::text-kit] USE="hunspell -aspell -nuspell -test -voikko" 0 KiB

Total: 1 package (1 reinstall), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) app-text/enchant-2.8.2::overlay
>>> Installing (1 of 1) app-text/enchant-2.8.2::overlay
>>> Recording app-text/enchant in "world" favorites file...
>>> Jobs: 1 of 1 complete                           Load avg: 0.29, 0.08, 0.03
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.

```
* Running it
```
workstation-mark-repo ~ # enchant-2 -v
@(#) International Ispell Version 3.1.20 (but really Enchant 2.8.2)
```