### PR TITLE
Update rust-bin.tmpl

### DIFF
--- a/lang-kit/curated/dev-lang/rust-bin/templates/rust-bin.tmpl
+++ b/lang-kit/curated/dev-lang/rust-bin/templates/rust-bin.tmpl
@@ -197,17 +197,17 @@ multilib_src_install() {
 	# https://github.com/rust-lang/rust/issues/125619
 	# https://github.com/llvm/llvm-project/pull/93890
 	# FL-12409.
-	if use arm64; then
-		if $(tc-getNM) "${ED}/opt/${P}/lib/rustlib/aarch64-unknown-linux-gnu/lib"/libcompiler_builtins-*.rlib |& grep -q "^[[:space:]]* U __builtin_copysignq$"; then
-			elog "Applying fix for undefined reference to __builtin_copysignq in ARM64 libcompiler_builtins-*.rlib"
-			$(tc-getCC) ${CPPFLAGS} ${CFLAGS} -c -o "${T}/__builtin_copysignq.o" -x c - <<<"_Float128 __builtin_copysignq(_Float128 x,_Float128 y){return __builtin_copysignf128(x, y);}" || die
-			$(tc-getAR) r "${ED}/opt/${P}/lib/rustlib/aarch64-unknown-linux-gnu/lib"/libcompiler_builtins-*.rlib "${T}/__builtin_copysignq.o" || die
-		else
-			eerror "ARM64 libcompiler_builtins-*.rlib no longer contains undefined reference to __builtin_copysignq"
-			eerror "Workaround code in ebuild should be deleted"
-			die "ARM64 libcompiler_builtins-*.rlib no longer contains undefined reference to __builtin_copysignq"
-		fi
-	fi
+	#if use arm64; then
+	#	if $(tc-getNM) "${ED}/opt/${P}/lib/rustlib/aarch64-unknown-linux-gnu/lib"/libcompiler_builtins-*.rlib |& grep -q "^[[:space:]]* U __builtin_copysignq$"; then
+	#		elog "Applying fix for undefined reference to __builtin_copysignq in ARM64 libcompiler_builtins-*.rlib"
+	#		$(tc-getCC) ${CPPFLAGS} ${CFLAGS} -c -o "${T}/__builtin_copysignq.o" -x c - <<<"_Float128 __builtin_copysignq(_Float128 x,_Float128 y){return __builtin_copysignf128(x, y);}" || die
+	#		$(tc-getAR) r "${ED}/opt/${P}/lib/rustlib/aarch64-unknown-linux-gnu/lib"/libcompiler_builtins-*.rlib "${T}/__builtin_copysignq.o" || die
+	#	else
+	#		eerror "ARM64 libcompiler_builtins-*.rlib no longer contains undefined reference to __builtin_copysignq"
+	#		eerror "Workaround code in ebuild should be deleted"
+	#		die "ARM64 libcompiler_builtins-*.rlib no longer contains undefined reference to __builtin_copysignq"
+	#	fi
+	#fi
 }
 
 pkg_postinst() {


### PR DESCRIPTION
deactivation of the workaround for rust-bin on ARM64 systems

Worked on my orange pi 5. Armv8.2a


```
opi5 ~ # genlop -i rust-bin
 * dev-lang/rust-bin


   Total builds: 7
   Global build time: 8 minutes and 36 seconds.
   Average merge time: 1 minute and 13 seconds.

   Info about currently installed ebuild:

   * dev-lang/rust-bin-1.82.0
   Install date: Fri Nov  1 13:53:00 2024
   USE=" -clippy -cpu_flags_x86_sse2 -doc -prefix -rustfmt -rust-src -wasm -wasm-wasi"
   CFLAGS="-march=armv8.2-a+crc+crypto -mtune=cortex-a76.cortex-a55 -O2 -pipe -ftree-vectorize -fomit-frame-pointer"   CXXFLAGS="-march=armv8.2-a+crc+crypto -mtune=cortex-a76.cortex-a55 -O2 -pipe -ftree-vectorize -fomit-frame-pointer"   LDFLAGS="-Wl,-O1 -Wl,--as-needed"
```


