### PR TITLE
[core-kit] [bugfix] Fix genkernel compatibility with updated linux-headers

### DIFF
--- a/core-kit/curated/sys-kernel/genkernel/autogen.yaml
+++ b/core-kit/curated/sys-kernel/genkernel/autogen.yaml
@@ -8,7 +8,7 @@ genkernel_rule:
         version: 4.3.10
         # so that people get the dmraid gz -> bz2 fix
         revision:
-          '4.3.10': '3'
+          '4.3.10': '4'
         patches:
           - 4.3.10-fix-modinfo-error.patch
         github:
@@ -19,7 +19,7 @@ genkernel_rule:
           bcache-tools-1.0.8_p20141204.tar.gz: https://github.com/g2p/bcache-tools/archive/399021549984ad27bf4a13ae85e458833fe003d7.tar.gz
           boost_1_79_0.tar.bz2: https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2
           btrfs-progs-v6.3.2.tar.xz: https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v6.3.2.tar.xz
-          busybox-1.36.1.tar.bz2: https://www.busybox.net/downloads/busybox-1.36.1.tar.bz2
+          busybox-1.37.0.tar.bz2: https://www.busybox.net/downloads/busybox-1.37.0.tar.bz2
           coreutils-9.4.tar.xz:  https://ftpmirror.gnu.org/coreutils/coreutils-9.4.tar.xz
           cryptsetup-2.6.1.tar.xz: https://www.kernel.org/pub/linux/utils/cryptsetup/v2.6/cryptsetup-2.6.1.tar.xz
           # orig at: ... has newer crypto than we support

--- a/core-kit/curated/sys-kernel/genkernel/files/share/patches/busybox/1.37.0/busybox-1.36.1-no-cbq.patch
+++ b/core-kit/curated/sys-kernel/genkernel/files/share/patches/busybox/1.37.0/busybox-1.36.1-no-cbq.patch
@@ -1,0 +1,49 @@
+diff -up busybox-1.36.1/networking/tc.c.no-cbq busybox-1.36.1/networking/tc.c
+--- busybox-1.36.1/networking/tc.c.no-cbq	2024-01-29 10:24:09.135082923 -0500
++++ busybox-1.36.1/networking/tc.c	2024-01-29 10:28:12.009502552 -0500
+@@ -31,7 +31,7 @@
+ //usage:	"qdisc [handle QHANDLE] [root|"IF_FEATURE_TC_INGRESS("ingress|")"parent CLASSID]\n"
+ /* //usage: "[estimator INTERVAL TIME_CONSTANT]\n" */
+ //usage:	"	[[QDISC_KIND] [help|OPTIONS]]\n"
+-//usage:	"	QDISC_KIND := [p|b]fifo|tbf|prio|cbq|red|etc.\n"
++//usage:	"	QDISC_KIND := [p|b]fifo|tbf|prio|red|etc.\n"
+ //usage:	"qdisc show [dev STRING]"IF_FEATURE_TC_INGRESS(" [ingress]")"\n"
+ //usage:	"class [classid CLASSID] [root|parent CLASSID]\n"
+ //usage:	"	[[QDISC_KIND] [help|OPTIONS] ]\n"
+@@ -230,7 +230,7 @@ static int cbq_parse_opt(int argc, char
+ {
+ 	return 0;
+ }
+-#endif
++
+ static int cbq_print_opt(struct rtattr *opt)
+ {
+ 	struct rtattr *tb[TCA_CBQ_MAX+1];
+@@ -322,6 +322,7 @@ static int cbq_print_opt(struct rtattr *
+  done:
+ 	return 0;
+ }
++#endif
+ 
+ static FAST_FUNC int print_qdisc(
+ 		const struct sockaddr_nl *who UNUSED_PARAM,
+@@ -373,7 +374,8 @@ static FAST_FUNC int print_qdisc(
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			prio_print_opt(tb[TCA_OPTIONS]);
+ 		} else if (qqq == 1) { /* class based queuing */
+-			cbq_print_opt(tb[TCA_OPTIONS]);
++			/* cbq_print_opt(tb[TCA_OPTIONS]); */
++			printf("cbq not supported");
+ 		} else {
+ 			/* don't know how to print options for this qdisc */
+ 			printf("(options for %s)", name);
+@@ -444,7 +446,8 @@ static FAST_FUNC int print_class(
+ 			/* nothing. */ /*prio_print_opt(tb[TCA_OPTIONS]);*/
+ 		} else if (qqq == 1) { /* class based queuing */
+ 			/* cbq_print_copt() is identical to cbq_print_opt(). */
+-			cbq_print_opt(tb[TCA_OPTIONS]);
++			/* cbq_print_opt(tb[TCA_OPTIONS]); */
++			printf("cbq not supported");
+ 		} else {
+ 			/* don't know how to print options for this class */
+ 			printf("(options for %s)", name);

--- a/core-kit/curated/sys-kernel/genkernel/templates/genkernel.tmpl
+++ b/core-kit/curated/sys-kernel/genkernel/templates/genkernel.tmpl
@@ -11,7 +11,7 @@ inherit bash-completion-r1 python-single-r1
 VERSION_BCACHE_TOOLS="1.0.8_p20141204"
 VERSION_BOOST="1.79.0"
 VERSION_BTRFS_PROGS="6.3.2"
-VERSION_BUSYBOX="1.36.1"
+VERSION_BUSYBOX="1.37.0"
 VERSION_COREUTILS="9.4"
 VERSION_CRYPTSETUP="2.6.1"
 VERSION_DMRAID="1.0.0.rc16-3"
@@ -190,6 +190,9 @@ src_install() {
 		bzip2 - -c > dmraid-${VERSION_DMRAID}.tar.bz2 && \
 		rm dmraid-${VERSION_DMRAID}.tar.gz
 	popd &>/dev/null || die
+
+	insinto /usr/share/genkernel/patches/busybox/1.37.0
+	doins "${FILESDIR}"/share/patches/busybox/1.37.0/*.patch
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Since `linux-6.8`, changes to the kernel headers necessitate a patch for `busybox-1.36.1` and `busybox-1.37.0`.

This PR does the following:
- Add patch from `sys-apps/busybox` to genkernel's installed files
- (genkernel automatically applies the patch)
- Bump genkernel's internal busybox version to match the current one in MARK tree

Tested with `metro` from a dev tree.  Originally found the issue during `metro` builds on `mark-testing`.  In the `metro` environment, there aren't any cached genkernel `initramfs` segments, so `busybox` needs to be built.  With this patch, `metro` builds succeed on the `mark-testing` tree.