### PR TITLE
[net-kit] net-misc/freerdp pin v3.5.1

### DIFF
--- a/net-kit/curated/net-misc/freerdp/autogen.yaml
+++ b/net-kit/curated/net-misc/freerdp/autogen.yaml
@@ -4,7 +4,7 @@ freerdp:
     - freerdp:
         homepage: http://www.freerdp.com/
         tarball: freerdp-{version}.tar.gz
-        version: 3.6.2
+        version: 3.5.1
         github:
           user: FreeRDP
           repo: FreeRDP


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#84

Emerge:
```
>>> Installing (1 of 1) net-misc/freerdp-3.5.1::net-kit
```

doit:
```
$ doit --release mark
INFO     Autogen: net-misc/freerdp-3.5.1                                                                                                                                                     
INFO     Created: freerdp-3.5.1.ebuild                                               
```