### PR TITLE
[net-kit] net-p2p/qbittorrent pinned v4.6.7

### DIFF
--- a/net-kit/curated/net-p2p/qbittorrent/autogen.yaml
+++ b/net-kit/curated/net-p2p/qbittorrent/autogen.yaml
@@ -5,4 +5,5 @@ qbt:
         github:
           repo: qBittorrent
           query: tags
+          release: '4.6.7'
           match: ^release-([0-9.]+)$


### PR DESCRIPTION
The new versions need openssl 3.x

Closes: macaroni-os/mark-issues#190