### PR TITLE
[desktop-kit] [bugfix] Update `passwordsafe` autogen.py: `name` -> `body`

### DIFF
--- a/desktop-kit/curated/app-admin/passwordsafe/autogen.py
+++ b/desktop-kit/curated/app-admin/passwordsafe/autogen.py
@@ -9,7 +9,7 @@ async def generate(hub, **pkginfo):
 	for release in json_list:
 		if release["prerelease"] or release["draft"]:
 			continue
-		if "Linux" not in release["name"]:
+		if "Linux" not in release["body"]:
 			continue
 		version = release["tag_name"]
 		url = f"https://github.com/pwsafe/pwsafe/archive/{version}.tar.gz"


### PR DESCRIPTION
The string "Linux" seems to occur more often in the `body` field than in the `name`, where it is never found (anymore?).  In fact, `name` is most often empty, or only a numerical version.  This patch fixes the autogen by pointing the search at `body` instead of `name`.