### PR TITLE
net-analyzer/mtr autogened

### DIFF
--- a/net-kit/next/net-analyzer/mtr/autogen.yaml
+++ b/net-kit/next/net-analyzer/mtr/autogen.yaml
@@ -1,0 +1,12 @@
+mtr_rule:
+  generator: github-1
+  packages:
+    - mtr:
+        github:
+          user: traviscross
+          query: tags
+          transform:
+            - kind: string
+              match: 'v'
+              replace: ''
+

--- a/net-kit/next/net-analyzer/mtr/templates/mtr.tmpl
+++ b/net-kit/next/net-analyzer/mtr/templates/mtr.tmpl
@@ -1,0 +1,61 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit autotools eutils fcaps flag-o-matic
+
+DESCRIPTION="My TraceRoute, an Excellent network diagnostic tool"
+HOMEPAGE="http://www.bitwizard.nl/mtr/"
+SRC_URI="{{src_uri}}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="*"
+IUSE="gtk ipv6 ncurses"
+
+S="${WORKDIR}/{{github_user}}-{{github_repo}}-{{sha[:7]}}"
+
+RDEPEND="
+        gtk? (
+                dev-libs/glib:2
+                x11-libs/gtk+:2
+        )
+        ncurses? ( sys-libs/ncurses:0= )
+"
+DEPEND="
+        ${RDEPEND}
+        sys-devel/autoconf
+        virtual/pkgconfig
+"
+
+DOCS=( AUTHORS FORMATS NEWS README.md SECURITY TODO )
+FILECAPS=( cap_net_raw usr/sbin/mtr-packet )
+
+src_prepare() {
+        default
+
+        eautoreconf
+}
+
+src_configure() {
+        # In the source's configure script -lresolv is commented out. Apparently it
+        # is needed for 64bit macos still.
+        [[ ${CHOST} == *-darwin* ]] && append-libs -lresolv
+        econf \
+                $(use_enable ipv6) \
+                $(use_with gtk) \
+                $(use_with ncurses)
+}
+
+src_test() {
+        [[ "$UID" = 0 ]] && default
+}
+
+pkg_postinst() {
+        fcaps_pkg_postinst
+
+        if use prefix && [[ ${CHOST} == *-darwin* ]] ; then
+                ewarn "mtr needs root privileges to run.  To grant them:"
+                ewarn " % sudo chown root ${EPREFIX}/usr/sbin/mtr"
+                ewarn " % sudo chmod u+s ${EPREFIX}/usr/sbin/mtr"
+        fi
+}

--- a/net-kit/next/packages.yaml
+++ b/net-kit/next/packages.yaml
@@ -194,7 +194,6 @@ packages:
   - net-analyzer/mping
   - net-analyzer/mrtg
   - net-analyzer/mrtg-ping-probe
-  - net-analyzer/mtr
   - net-analyzer/multimon-ng
   - net-analyzer/munin
   - net-analyzer/munin-plugins-zfs

--- a/net-kit/packages.yaml
+++ b/net-kit/packages.yaml
@@ -1174,7 +1174,6 @@ packages:
   - net-analyzer/ngrep
   - net-analyzer/ifstatus
   - net-analyzer/openvas
-  - net-analyzer/mtr
   - net-analyzer/nagios-check_rbl
   - net-analyzer/carl
   - net-analyzer/flent


### PR DESCRIPTION
Summary
========
* autogened net-analyzer/mtr 

Test Plan
========
* Doit
```
 ╰ $ doit
INFO     Autogen: net-analyzer/mtr (latest)                                                                                                                                                                                                                                                                         
INFO     Download from https://github.com/traviscross/mtr/tarball/852e5617fbf331cf292723702161f0ac9afe257c verified as valid tar.gz archive.                                                                                                                                                                        
INFO     Created: mtr-0.95.ebuild   
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
~ # emerge -av net-analyzer/mtr

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild  N     ] net-analyzer/mtr-0.95::public-overlay  USE="filecaps gtk ipv6 ncurses" 0 KiB

Total: 1 package (1 new), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) net-analyzer/mtr-0.95::public-overlay
>>> Installing (1 of 1) net-analyzer/mtr-0.95::public-overlay
>>> Recording net-analyzer/mtr in "world" favorites file...
>>> Jobs: 1 of 1 complete                           Load avg: 1.63, 1.56, 1.49
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
```
* Running it
![image](https://github.com/user-attachments/assets/0087cafc-9725-42ba-900c-da3293cb28d3)
