### PR TITLE
=dev-python/packaging-24.2 with new module 'packaging.licenses'

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -5,7 +5,7 @@ oddball_core_deps:
   generator: pypi-compat-1
   packages:
     - packaging:
-        version: '21.3'
+        version: '24.2'
         blocker: "!<=dev-python/packaging-18.0"
         python_compat: python3+
         pydeps:


### PR DESCRIPTION
Summary
========
* Updated dev-python/packaging to 24.2 needed for =dev-python/hatchling-1.26.0
* Closes: macaroni-os/mark-issues#201

Test Plan
========
* Doit
```
 ╰ $ doit --pkg packaging
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                                                                                                                            
INFO     Autogen: dev-python/packaging-24.2                                                                                                                                                                                                                                                                         
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                                                                                                                            
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                                                                                                                            
INFO     Download from https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz verified as valid tar.gz archive.                                                                                                                           
INFO     Created: packaging/packaging-24.2.ebuild                                                                                                                                                                                                                                                                   
INFO     Download from https://files.pythonhosted.org/packages/86/3c/bcd09ec5df7123abcf695009221a52f90438d877a2f1499453c6938f5728/packaging-20.9.tar.gz verified as valid tar.gz archive.                                                                                                                           
INFO     Created: packaging-compat/packaging-compat-20.9.ebuild 
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
~ # emerge -av packaging

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] dev-python/packaging-24.2::public-overlay [21.3::python-modules-kit] PYTHON_TARGETS="python3_9 -python2_7 -python3_10 -python3_7 -python3_8" 161 KiB

Total: 1 package (1 upgrade), Size of downloads: 161 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-python/packaging-24.2::public-overlay
>>> Installing (1 of 1) dev-python/packaging-24.2::public-overlay
>>> Recording dev-python/packaging in "world" favorites file...
>>> Jobs: 1 of 1 complete                           Load avg: 1.88, 1.75, 1.31
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
~ # emerge -av dev-python/hatchling

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] dev-python/hatchling-1.26.0::python-modules-kit [1.25.0::python-modules-kit] PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8" 0 KiB

Total: 1 package (1 upgrade), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-python/hatchling-1.26.0::python-modules-kit
>>> Installing (1 of 1) dev-python/hatchling-1.26.0::python-modules-kit
>>> Jobs: 1 of 1 complete                           Load avg: 1.90, 1.76, 1.34
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.

```
