### PR TITLE
[python-modules-kit] dev-python/async_timeout review template

### DIFF
--- a/python-modules-kit/curated/dev-python/templates/async_timeout.tmpl
+++ b/python-modules-kit/curated/dev-python/templates/async_timeout.tmpl
@@ -5,26 +5,20 @@ PYTHON_COMPAT=( {{python_compat}} )
 
 inherit distutils-r1
 
-MY_P=${PN/_/-}-${PV}
 DESCRIPTION="Timeout context manager for asyncio programs"
 HOMEPAGE="https://github.com/aio-libs/async-timeout"
-SRC_URI="{{artifacts[0].src_uri}}"
+SRC_URI="{{ src_uri }}"
 
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="*"
-IUSE="test"
-S=${WORKDIR}/${MY_P}
+IUSE=""
 
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]
 	dev-python/setuptools_scm[${PYTHON_USEDEP}]
-	test? ( dev-python/pytest-aiohttp[${PYTHON_USEDEP}] )"
+"
 
 python_prepare_all() {
 	sed -i "s:, 'pytest-runner'::" -i setup.py || die
 	distutils-r1_python_prepare_all
-}
-
-python_test() {
-	py.test -v || die "Tests fail with ${EPYTHON}"
 }


### PR DESCRIPTION
The package `dev-python/async_timeout` doesn't need anymore the MY_PV variable.

Closes: macaroni-os/mark-issues#202