### PR TITLE
[python-modules-kit] dev-python/webcolors autogen review

### DIFF
--- a/core-kit/curated/eclass/distutils-r1.eclass
+++ b/core-kit/curated/eclass/distutils-r1.eclass
@@ -251,7 +251,7 @@ _distutils_set_globals() {
 					>=dev-python/pbr-5.8.0-r1[${PYTHON_USEDEP}]
 				'
 				;;
-			pdm)
+			pdm|pdm-backend)
 				bdep+='
 					>=dev-python/pdm-pep517-1.0.0[${PYTHON_USEDEP}]
 				'
@@ -1183,8 +1183,8 @@ _distutils-r1_backend_to_key() {
 		pbr.build)
 			echo pbr
 			;;
-		pdm.pep517.api)
-			echo pdm
+		pdm.backend|pdm.pep517.api)
+			echo pdm-backend
 			;;
 		poetry.core.masonry.api|poetry.masonry.api)
 			echo poetry

--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -99,8 +99,6 @@ autogens:
     - strict-rfc3339
     - typing-extensions:
         du_pep517: flit
-    - webcolors:
-        blocker: '!<dev-python/webcolors-1.9'
     - zipp:
         python_compat: python3+ pypy3
         blocker: '!<=dev-python/zipp-2'
@@ -266,6 +264,8 @@ setuptools_builds:
         - setuptools
   generator: pypi-simple-1
   packages:
+    - webcolors:
+        blocker: '!<dev-python/webcolors-1.9'
     - python-magic:
         license: BSD-2 MIT
         desc: "Access the libmagic file type identification library"

--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -223,9 +223,33 @@ github_pythons:
 setuptools_standalone_pythons:
   generator: pypi-simple-1
   defaults:
+    du_pep517: standalone
     python_compat: python3+
 
   packages:
+    - pdm-backend:
+        body: |
+          src_prepare() {
+              rm -r src/pdm/backend/_vendor || die
+              find -name '*.py' -exec sed \
+                  -e 's:from pdm\.backend\._vendor\.:from :' \
+                  -e 's:from pdm\.backend\._vendor ::' \
+                  -e 's:import pdm\.backend\._vendor\.:import :' \
+                  -i {} + || die
+              distutils-r1_src_prepare
+          }
+        pydeps:
+          py:all:build:
+            - editables
+            - packaging >= 24.0
+            - pyproject-metadata
+            - tomli
+          py:all:runtime:
+            - editables
+            - packaging >= 24.0
+            - pyproject-metadata
+            - tomli
+
     - setuptools_scm:
         body : |
           src_configure() {
@@ -239,7 +263,6 @@ setuptools_standalone_pythons:
             distutils-r1_src_configure
           }
 
-        du_pep517: standalone
         iuse: test
 
         pydeps:

--- a/python-modules-kit/packages.yaml
+++ b/python-modules-kit/packages.yaml
@@ -721,7 +721,6 @@ packages:
   - dev-python/mando
   - dev-python/configshell-fb
   - dev-python/pyscaffold
-  - dev-python/webcolors
   - dev-python/pyftpdlib
   - dev-python/mamba
   - dev-python/pexpect


### PR DESCRIPTION
In order to compile the new versions of `dev-python/webcolors` we need the `pdm-backend`.

This PR introduces:
* migration of `dev-python/webcolors` to `pypi-simple-1` generator
* add `dev-python/pdm-backend` package autogen
* review `distutils-r1` eclass

Closes: macaroni-os/mark-issues#204