### PR TITLE
[python-modules-kit] dev-python/pyrfc3339 - fix pypiname

### DIFF
--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -68,7 +68,6 @@ autogens:
             - setuptools
     - pyinotify
     - pyrfc3339:
-        pypi_name: pyRFC3339
         pydeps:
           - pytz
     - regex

--- a/python-modules-kit/packages.yaml
+++ b/python-modules-kit/packages.yaml
@@ -62,7 +62,6 @@ packages:
   - dev-python/pickleshare
   - dev-python/dugong
   - dev-python/pygame_sdl2
-  - dev-python/pyrfc3339
   - dev-python/python-prctl
   - dev-python/scripttest
   - dev-python/d2to1


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#207