### PR TITLE
[python-modules-kit] Add dev-python/packaging-legacy

### DIFF
--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -294,6 +294,7 @@ setuptools_builds:
             - setuptools_scm
     - webcolors:
         blocker: '!<dev-python/webcolors-1.9'
+    - packaging-legacy
     - python-magic:
         license: BSD-2 MIT
         desc: "Access the libmagic file type identification library"


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#215

```
 doit --release mark --pkg packaging-legacy
INFO     Autogen: dev-python/packaging-legacy (latest)                                                                                                                                                              
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                            
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                            
WARNING  dict key du_pep517 overwritten.                                                                                                                                                                            
INFO     Created: packaging-legacy/packaging-legacy-23.0_p0.ebuild      
```