### PR TITLE
[core-kit] Bump sys-apps/metatools-1.3.8_p20241117

### DIFF
--- a/core-kit/mark/sys-apps/metatools/autogen.yaml
+++ b/core-kit/mark/sys-apps/metatools/autogen.yaml
@@ -6,9 +6,9 @@ metatools_github_rule:
         license: Apache-2.0
         desc: "M.A.R.K. metatools -- autogeneration framework."
         homepage: "https://github.com/macaroni-os/funtoo-metatools"
-        version: 1.3.8_pre20240818
+        version: 1.3.8_pre20241117
         github:
           user: macaroni-os
           repo: funtoo-metatools
           query: snapshot
-          snapshot: 4d65e4a0890f2a0caa860c5429b58e70eebe9bea
+          snapshot: a329987c75e8d11789c804c67070f563360eb07e

--- a/core-kit/mark/sys-apps/metatools/templates/metatools.tmpl
+++ b/core-kit/mark/sys-apps/metatools/templates/metatools.tmpl
@@ -18,6 +18,7 @@ RDEPEND="
 	>=dev-python/httpx-0.24.0[${PYTHON_USEDEP}]
 	>=dev-python/jinja-3[${PYTHON_USEDEP}]
 	dev-python/packaging[${PYTHON_USEDEP}]
+	dev-python/packaging-legacy[${PYTHON_USEDEP}]
 	dev-python/psutil[${PYTHON_USEDEP}]
 	dev-python/pymongo[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#217