### PR TITLE
Review `gnu-1` generator to support packaging-24

### DIFF
--- a/generators/gnu-1.py
+++ b/generators/gnu-1.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from metatools.generator.common import common_init
+from metatools.version import generic
 from bs4 import BeautifulSoup
 from packaging import version
 import re
@@ -23,9 +24,7 @@ def sort_url_and_vstr_tuples(tuple_list):
 			# initial sanity check to skip anything more complicated than 1.2.3 ( 1.2.3-rc1, for example):
 			if not re.fullmatch('[\d.]+', v_str):
 				raise version.InvalidVersion(f"skipping {v_str}")
-			v_obj = version.parse(v_str)
-			if v_obj.__class__.__name__ == "LegacyVersion":
-				continue
+			v_obj = generic.parse(v_str)
 		except version.InvalidVersion:
 			continue
 		unsorted_list.append((url, v_str, v_obj))


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#218


```
# doit --release mark
INFO     Autogen: sys-apps/util-linux (latest)                                                                                                                                                                      
INFO     Download from https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.2.tar.xz verified as valid tar.xz archive.                                                                  
INFO     Created: util-linux-2.40.2.ebuild                                                                                                                                                                          
```

`util-linux` uses `gnu-1` generator.
