### PR TITLE
[core-kit] sys-apps/metatools: Bump v1.3.8_p20241118

### DIFF
--- a/core-kit/mark/sys-apps/metatools/autogen.yaml
+++ b/core-kit/mark/sys-apps/metatools/autogen.yaml
@@ -6,9 +6,9 @@ metatools_github_rule:
         license: Apache-2.0
         desc: "M.A.R.K. metatools -- autogeneration framework."
         homepage: "https://github.com/macaroni-os/funtoo-metatools"
-        version: 1.3.8_pre20241117
+        version: 1.3.8_pre20241118
         github:
           user: macaroni-os
           repo: funtoo-metatools
           query: snapshot
-          snapshot: a329987c75e8d11789c804c67070f563360eb07e
+          snapshot: 3ca77d7dac6b9256e161d0bce47c7f7eb85e6e96


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#217
