### PR TITLE
[python-modules-kit] dev-python/python-xlib review backend

### DIFF
--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -178,47 +178,6 @@ pypi_compat_rule:
         pydeps:
           - markupsafe
 
-github_pythons:
-  generator: python-github-1
-  defaults:
-    python_compat: python3+ pypy3
-  packages:
-    - python-xlib:
-        desc: A fully functional X client library for Python, written in Python
-        github:
-          query: releases
-        pydeps:
-          py:all:
-            - six
-          py:all:build:
-            - setuptools_scm
-            - packaging
-          use:test:
-            - mock
-        depend: |
-          doc? ( sys-apps/texinfo )
-        iuse: doc test
-        inherit:
-          - virtualx
-        license: LGPL-2+
-        body: |
-          python_compile_all() {
-            use doc && emake -C doc/info
-          }
-
-          src_test() {
-            virtx distutils-r1_src_test
-          }
-
-          python_test() {
-            "${EPYTHON}" -m unittest discover -v || die "Tests fail with ${EPYTHON}"
-          }
-
-          python_install_all() {
-            use doc && doinfo doc/info/*.info
-            distutils-r1_python_install_all
-          }
-
 setuptools_standalone_pythons:
   generator: pypi-simple-1
   defaults:
@@ -275,6 +234,40 @@ setuptools_standalone_pythons:
             - build
             - typing_extensions
 
+github_pythons:
+  generator: python-github-1
+  defaults:
+    python_compat: python3+ pypy3
+    du_pep517: setuptools
+    pydeps:
+      py:all:build:
+        - setuptools
+  packages:
+    - python-xlib:
+        desc: A fully functional X client library for Python, written in Python
+        github:
+          query: releases
+        pydeps:
+          py:all:
+            - six
+          py:all:build:
+            - setuptools_scm
+            - packaging
+        depend: |
+          doc? ( sys-apps/texinfo )
+        iuse: doc
+        inherit:
+          - virtualx
+        license: LGPL-2+
+        body: |
+          python_compile_all() {
+            use doc && emake -C doc/info
+          }
+
+          python_install_all() {
+            use doc && doinfo doc/info/*.info
+            distutils-r1_python_install_all
+          }
 
 setuptools_builds:
   defaults:

--- a/python-modules-kit/packages.yaml
+++ b/python-modules-kit/packages.yaml
@@ -618,7 +618,6 @@ packages:
   - dev-python/httmock
   - dev-python/yapsy
   - dev-python/rackspace-novaclient
-  - dev-python/python-xlib
   - dev-python/bcrypt
   - dev-python/pytest-helpers-namespace
   - dev-python/xapp


### PR DESCRIPTION
In order to compile this package with packaging 24 we need to use the setuptools backend.

Closes: macaroni-os/mark-issues#220