### PR TITLE
app-office/libreoffice-bin ensures the script fetches the correct latest version of LibreOffice binaries

### DIFF
--- a/desktop-kit/curated/app-office/libreoffice-bin/autogen.py
+++ b/desktop-kit/curated/app-office/libreoffice-bin/autogen.py
@@ -140,11 +140,11 @@ async def autogen_libreoffice(hub, pkginfo, version="latest", gen={"main", "l10n
 	"""
 	libre_regex = "LibreOffice_([0-9.]+)_Linux_x86-64_rpm"
 	if version == "latest":
-		mirror = "https://mirror1.cs-georgetown.net/tdf/libreoffice"
-		base_url = f"{mirror}/stable"
+		mirror = "https://downloadarchive.documentfoundation.org/libreoffice/old/"
+		base_url = f"{mirror}"
 		main_version = hub.pkgtools.pages.latest(await hub.pkgtools.pages.iter_links(
 			base_url=base_url,
-			match_fn=lambda x: re.match(f"([0-9]\.[0-9]\.[0-9])/", x),
+			match_fn=lambda x: re.match(f"(\d+\.\d+\.\d+.\d+)/", x),
 			fixup_fn=lambda x: x.groups()[0],
 		))
 		dl_url = base_url + f"/{main_version}/rpm/x86_64"


### PR DESCRIPTION
…etching


Summary
========
* changed the mirror URL to the document foundation archive 
* updated the regular expression for matching version numbers to be more precise. 

Test Plan
========
* Doit
```
doit
INFO     Autogen: app-office/libreoffice-bin (latest)                                                                                                                                                                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm.tar.gz verified as valid tar.gz archive.                                  
INFO     Created: libreoffice-bin-24.8.3.2.ebuild                                                                                                                                                                          
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_bn.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_as.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_am.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_brx.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_bs.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_bn-IN.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ast.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_af.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_cs.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ca.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_bg.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ca-valencia.tar.gz verified as valid tar.gz archive.             
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_bo.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ar.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_da.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ckb.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_de.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_dgo.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_cy.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_dsb.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_br.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_dz.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_fur.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_fy.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ga.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_en-ZA.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_zh-TW.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_be.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_fr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sd.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_gug.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_fi.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_hi.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_et.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_fa.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_eu.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_he.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_hsb.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_gd.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_gu.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_hy.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_eo.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_tg.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_el.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_hr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_id.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_kab.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ja.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_is.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_hu.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_es.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_kmr-Latn.tar.gz verified as valid tar.gz archive.                
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_kk.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_lb.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_kok.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_gl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ks.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_kn.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ka.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_km.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_it.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_lo.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_mai.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ko.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_lt.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_lv.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_mni.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_mk.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_mr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_en-GB.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_my.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_nr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ml.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_rw.tar.gz verified as valid tar.gz archive.                      
 37% LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_pt-BR.tar.gz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.2/5.8 MB     1.6 MB/s 
 79%    LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_pt.tar.gz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.9/2.4 MB     1.6 MB/s 
 65%    LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ro.tar.gz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.5/2.3 MB     1.3 MB/s 
 57%    LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sr.tar.gz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.6/2.8 MB     1.4 MB/s 
 36%    LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_nn.tar.gz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/3.6 MB     1.3 MB/s 
 36%    LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_nb.tar.gz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/3.6 MB     1.5 MB/s 
 38%    LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ru.tar.gz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.8/2.2 MB     1.3 MB/s 
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ne.tar.gz verified as valid tar.gz archive.                      
 37% LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_pt-BR.tar.gz ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.2/5.8 MB     1.6 MB/s 
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sat.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_mn.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sa-IN.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sid.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_nso.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_si.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_pt.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ro.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_oc.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_om.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_or.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_nl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ru.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_pa-IN.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ss.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_nb.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sw-TZ.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_nn.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_st.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sq.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sk.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_tg.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ta.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_szl.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_pt-BR.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_te.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_tn.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ts.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_tt.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sr-Latn.tar.gz verified as valid tar.gz archive.                 
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_th.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ve.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_uz.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_tl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_ug.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_pl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_sv.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_vec.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_xh.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_vi.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_zh-CN.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_zh-TW.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_zu.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_uk.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ar.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_bo.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ast.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_bg.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_da.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ca.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ca-valencia.tar.gz verified as valid tar.gz archive.             
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_am.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_en-US.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_de.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_bn-IN.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_langpack_tr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_dz.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_bn.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_dsb.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_cs.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_bs.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_eo.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_en-ZA.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_es.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_el.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_eu.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_et.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_en-GB.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_fr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_gl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_gu.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_fi.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_he.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_hi.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_hr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_id.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_hsb.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_is.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_hu.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_it.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ja.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ka.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_km.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ko.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_lo.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_lt.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_lv.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_mk.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_nb.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ne.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_nl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_nn.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_om.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_pl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_pt-BR.tar.gz verified as valid tar.gz archive.                   
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_pt.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ro.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_sid.tar.gz verified as valid tar.gz archive.                     
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ru.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_si.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_sk.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_sl.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_sq.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_sv.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ta.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_tr.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_uk.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_vi.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_ug.tar.gz verified as valid tar.gz archive.                      
INFO     Download from https://downloadarchive.documentfoundation.org/libreoffice/old//24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm_helppack_zh-CN.tar.gz verified as valid tar.gz archive.                   
INFO     Created: ../libreoffice-l10n/libreoffice-l10n-24.8.3.2.ebuild
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
workstation-mark-repo ~ # emerge libreoffice-bin

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild  N     ] app-text/libexttextcat-3.4.5  USE="-static-libs" 
[ebuild  N     ] media-fonts/liberation-fonts-2.1.0  USE="X -fontforge" 
[ebuild  N     ] app-office/libreoffice-l10n-24.8.3.2  USE="-offlinehelp" L10N="-af -am -ar -as -ast -be -bg -bn -bn-IN -bo -br -brx -bs -ca -ca-valencia -ckb -cs -cy -da -de -dgo -dsb -dz -el -en -en-GB -en-ZA -eo -es -et -eu -fa -fi -fr -fur -fy -ga -gd -gl -gu -gug -he -hi -hr -hsb -hu -hy -id -is -it -ja -ka -kab -kk -km -kmr-Latn -kn -ko -kok -ks -lb -lo -lt -lv -mai -mk -ml -mn -mni -mr -my -nb -ne -nl -nn -nr -nso -oc -om -or -pa -pl -pt -pt-BR -ro -ru -rw -sa -sat -sd -si -sid -sk -sl -sq -sr -sr-Latn -ss -st -sv -sw-TZ -szl -ta -te -tg -th -tl -tn -tr -ts -tt -ug -uk -uz -ve -vec -vi -xh -zh-CN -zh-TW -zu" 
[ebuild  N     ] dev-libs/librevenge-0.0.4-r1  USE="-doc -test" 
[ebuild  N     ] app-text/libmwaw-0.3.15  USE="-doc -static-libs -tools" 
[ebuild  N     ] app-office/libreoffice-bin-24.8.3.2  USE="gnome gtk -java -kde" 

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 6) app-text/libexttextcat-3.4.5::text-kit
>>> Installing (1 of 6) app-text/libexttextcat-3.4.5::text-kit
>>> Emerging (2 of 6) media-fonts/liberation-fonts-2.1.0::media-kit
>>> Installing (2 of 6) media-fonts/liberation-fonts-2.1.0::media-kit
>>> Emerging (3 of 6) app-office/libreoffice-l10n-24.8.3.2::overlay
>>> Installing (3 of 6) app-office/libreoffice-l10n-24.8.3.2::overlay
>>> Emerging (4 of 6) dev-libs/librevenge-0.0.4-r1::dev-kit
>>> Installing (4 of 6) dev-libs/librevenge-0.0.4-r1::dev-kit
>>> Emerging (5 of 6) app-text/libmwaw-0.3.15::text-kit
>>> Installing (5 of 6) app-text/libmwaw-0.3.15::text-kit
>>> Emerging (6 of 6) app-office/libreoffice-bin-24.8.3.2::overlay
>>> Installing (6 of 6) app-office/libreoffice-bin-24.8.3.2::overlay
>>> Recording app-office/libreoffice-bin in "world" favorites file...
>>> Jobs: 6 of 6 complete                           Load avg: 3.14, 1.68, 0.66

 * Messages for package media-fonts/liberation-fonts-2.1.0:

 * The following fontconfig configuration files have been installed:
 * 
 *   60-liberation.conf
 * 
 * Use `eselect fontconfig` to enable/disable them.

 * Messages for package app-office/libreoffice-bin-24.8.3.2:

 * If you plan to use lbase application you should enable java or you will get various crashes.
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
workstation-mark-repo ~ # 

```
* Running it
![image](https://github.com/user-attachments/assets/7113cbed-7f60-4b2d-95cc-dfadb26e29bc)

