### PR TITLE
www-client/firefox updated to Firefox version 133.0

### DIFF
--- a/browser-kit/curated/www-client/firefox/autogen.yaml
+++ b/browser-kit/curated/www-client/firefox/autogen.yaml
@@ -6,9 +6,9 @@ firefox_gen:
   packages:
     - firefox:
         versions:
-          132.0:
+          133.0:
             unmasked: True
             description: "Firefox Web Browser"
             homepage: "https://www.mozilla.com/firefox"
-            patchset_tarball: "firefox-132-patches-01.tar.xz"
+            patchset_tarball: "firefox-133-patches-01.tar.xz"
             patchset_gentoo_dev: "juippis"


### PR DESCRIPTION
Summary
========
* Bump Firefox to version 133.0 in autogen.yaml. 
* Adjust associated patchset tarball to reflect the new version.

Test Plan
========
* Doit
```
~/Development/src/funtoo-infra-core/kit-fixups/browser-kit/curated/www-client/firefox git:[funmore]
doit
WARNING  dict key unmasked overwritten.                                                                                                                                                                                    
INFO     Autogen: www-client/firefox-133.0                                                                                                                                                                                 
INFO     Download from https://dev.gentoo.org/~juippis/mozilla/patchsets/firefox-133-patches-01.tar.xz verified as valid tar.xz archive.                                                                                   
INFO     Download from https://archive.mozilla.org/pub/firefox/releases/133.0/source/firefox-133.0.source.tar.xz verified as valid tar.xz archive.                                                                         
INFO     Created: firefox-133.0.ebuild                                                                                                                                                                                     

```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
~ # emerge -av www-client/firefox

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] www-client/firefox-133.0:0/133::public-overlay [132.0:0/132::public-overlay] USE="X clang dbus gmp-autoupdate openh264 pulseaudio system-jpeg system-libevent -debug -eme-free -geckodriver -hardened -hwaccel -jack -libproxy -lto -pgo -screencast (-selinux) -sndio -system-av1 -system-harfbuzz (-system-icu) -system-libvpx -system-png -system-python-libs -system-webp -wayland -wifi" L10N="de -ach -af -an -ar -ast -az -be -bg -bn -br -bs -ca -ca-valencia -cak -cs -cy -da -dsb -el -en-CA -en-GB -en-US -eo -es-AR -es-CL -es-ES -es-MX -et -eu -fa -ff -fi -fr -fur -fy-NL -ga-IE -gd -gl -gn -gu-IN -he -hi-IN -hr -hsb -hu -hy-AM -ia -id -is -it -ja -ka -kab -kk -km -kn -ko -lij -lt -lv -mk -mr -ms -my -nb-NO -ne-NP -nl -nn-NO -oc -pa-IN -pl -pt-BR -pt-PT -rm -ro -ru -sat -sc -sco -si -sk -skr -sl -son -sq -sr -sv-SE -szl -ta -te -tg -th -tl -tr -trs -uk -ur -uz -vi -xh -zh-CN -zh-TW" 0 KiB

Total: 1 package (1 upgrade), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Running pre-merge checks for www-client/firefox-133.0
 * Checking for at least 6600 MiB disk space at "/run/portage/www-client/firefox-133.0/temp" ...                                                                                                                                                                                   [ ok ]
>>> Emerging (1 of 1) www-client/firefox-133.0::public-overlay
>>> Installing (1 of 1) www-client/firefox-133.0::public-overlay
>>> Jobs: 1 of 1 complete                           Load avg: 19.1, 37.7, 23.4

 * Messages for package www-client/firefox-133.0:

 * 
 * Unfortunately Firefox-100.0 breaks compatibility with some sites using 
 * useragent checks. To temporarily fix this, enter about:config and modify 
 * network.http.useragent.forceVersion preference to "99".
 * Or install an addon to change your useragent.
 * See: https://support.mozilla.org/en-US/kb/difficulties-opening-or-using-website-firefox-100
 * 
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.

```
* Running it
![image](https://github.com/user-attachments/assets/1dcdc82e-b427-41d0-ab68-eb72f503ef4e)