### PR TITLE
[core-kit] sys-block/thin-provisioning-tools review template

### DIFF
--- a/core-kit/curated/sys-block/thin-provisioning-tools/templates/thin-provisioning-tools.tmpl
+++ b/core-kit/curated/sys-block/thin-provisioning-tools/templates/thin-provisioning-tools.tmpl
@@ -25,11 +25,11 @@ DEPEND="
 # bindgen needs libclang.so 
 
 BDEPEND="${RDEPEND}
-	  virtual/pkgconfig
+	virtual/pkgconfig
 	>=virtual/rust-1.75
-	  app-text/asciidoc 
-	  sys-devel/clang
-	  sys-fs/lvm2
+	app-text/asciidoc
+	sys-devel/clang
+	sys-fs/lvm2
 "
 
 
@@ -53,6 +53,11 @@ src_unpack() {
 	cargo_src_unpack
 	rm -rf ${S}
 	mv ${WORKDIR}/{{github_user}}-{{github_repo}}-* ${S} || die
+
+	# Patch rio library to ignore unused qualifications.
+	# Needed for io-uring use flag.
+	sed -i -e '/unused_qualifications/d' \
+		${WORKDIR}/funtoo-crates-bundle-${PN}/*rio-*/src/lib.rs
 }
 
 src_configure() {
@@ -76,4 +81,4 @@ src_install() {
 	einstalldocs
 }
 
-# vim: syn=ebuild ts=4 noet
+# vim: filetype=ebuild ts=4 noet


### PR DESCRIPTION
Fix compilation when `io-uring` use flag is enabled.

We need to disable unused_qualifications option from rio library.

Closes: macaroni-os/mark-issues#227