### PR TITLE
[core-kit] sys-fs/lvm2 avoid dep cycles with thin-provisioning-tools

### DIFF
--- a/core-kit/curated/sys-fs/lvm2/templates/lvm2.tmpl
+++ b/core-kit/curated/sys-fs/lvm2/templates/lvm2.tmpl
@@ -37,6 +37,10 @@ RDEPEND="
 	>=sys-apps/baselayout-2.2
 	lvm? (
 		virtual/tmpfiles
+	)
+"
+PDEPEND="
+	lvm? (
 		thin? ( >=sys-block/thin-provisioning-tools-1.0.6 )
 	)
 "


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#230