### PR TITLE
net-fs/minio net-fs/minio-client Added Golang extension to Minio and Minio-Client packages

### DIFF
--- a/net-kit/mark/net-fs/minio-client/autogen.yaml
+++ b/net-kit/mark/net-fs/minio-client/autogen.yaml
@@ -2,6 +2,8 @@ minio-client_rule:
   generator: github-1
   packages:
     - minio-client:
+        extensions:
+          - golang
         github:
           user: minio
           repo: mc

--- a/net-kit/mark/net-fs/minio/autogen.yaml
+++ b/net-kit/mark/net-fs/minio/autogen.yaml
@@ -2,6 +2,8 @@ minio_rule:
   generator: github-1
   packages:
     - minio:
+        extensions:
+          - golang
         github:
           user: minio
           query: releases


### PR DESCRIPTION
Summary
========
* This update enhances the autogen.yaml files by incorporating the Golang extension to both the Minio and Minio-Client packages. The inclusion aims to streamline development and integration processes related to these packages.
* Closes: macaroni-os/mark-issues#232

Test Plan
========
* Doit
```
 ╰ $ doit
INFO     Autogen: net-fs/minio (latest)                                                                                                                                                                                      
INFO     Download from https://github.com/minio/minio/tarball/bae05edea0dee78128e59013583b80a8d971c74e verified as valid tar.gz archive.                                                                                     
INFO     Created: minio-2024.11.07.ebuild    

 ╰ $ doit
INFO     Autogen: net-fs/minio-client (latest)                                                                                                                                                                               
INFO     Download from https://github.com/minio/mc/tarball/93606cc9894344135f249e40bdd28a635a221284 verified as valid tar.gz archive.                                                                                        
INFO     Created: minio-client-2024.11.17.ebuild    
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
lready up to date.
Updating /etc/portage/repos.conf...
Updating profiles at /etc/portage/make.profile/parent...
Sync successful and kits in alignment! :)

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] net-fs/minio-client-2024.11.17::net-kit [2024.11.05.11.29.45::net-kit] 72,098 KiB

Total: 1 package (1 upgrade), Size of downloads: 72,098 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) net-fs/minio-client-2024.11.17::net-kit
>>> Installing (1 of 1) net-fs/minio-client-2024.11.17::net-kit
>>> Jobs: 1 of 1 complete                           Load avg: 1.29, 0.33, 0.11
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

```
* Running it
```
~ # mc -version
mc version DEVELOPMENT.GOGET (commit-id=DEVELOPMENT.GOGET)
Runtime: go1.23.1 linux/amd64
Copyright (c) 2015-0000 MinIO, Inc.
License GNU AGPLv3 <https://www.gnu.org/licenses/agpl-3.0.html>

```
