### PR TITLE
[dev-kit] Ssh-compose autogen and minor fix for lxd-compose

### DIFF
--- a/dev-kit/mark/app-emulation/lxd-compose/templates/lxd-compose.tmpl
+++ b/dev-kit/mark/app-emulation/lxd-compose/templates/lxd-compose.tmpl
@@ -24,7 +24,7 @@ src_compile() {
 	)
 
 	CGO_ENABLED=0 go build \
-		-ldflags "${anise_ldflags[*]}" \
+		-ldflags "${lxdcompose_ldflags[*]}" \
 		-o ${PN} -v -x -mod=vendor . || die
 }
 

--- a/dev-kit/mark/dev-util/ssh-compose/autogen.yaml
+++ b/dev-kit/mark/dev-util/ssh-compose/autogen.yaml
@@ -1,0 +1,8 @@
+ssh_compose:
+  generator: github-1
+  packages:
+    - ssh-compose:
+        github:
+          user: MottainaiCI
+          repo: ssh-compose
+          query: releases

--- a/dev-kit/mark/dev-util/ssh-compose/templates/ssh-compose.tmpl
+++ b/dev-kit/mark/dev-util/ssh-compose/templates/ssh-compose.tmpl
@@ -1,0 +1,36 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="SSH Compose Orchestrator"
+HOMEPAGE="https://github.com/MottainaiCI/ssh-compose"
+SRC_URI="{{ src_uri }}"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="*"
+
+DEPEND="dev-lang/go"
+
+post_src_unpack() {
+	mv MottainaiCI-ssh-compose-* ${S}
+}
+
+src_compile() {
+	sshcompose_ldflags=(
+		"-X \"github.com/MottainaiCI/ssh-compose/cmd.BuildTime=$(date -u '+%Y-%m-%d %I:%M:%S %Z')\""
+		"-X github.com/MottainaiCI/ssh-compose/cmd.BuildCommit={{ sha }}"
+		"-X github.com/MottainaiCI/ssh-compose/cmd.BuildGoVersion=$(go env GOVERSION)"
+	)
+
+	CGO_ENABLED=0 go build \
+		-ldflags "${sshcompose_ldflags[*]}" \
+		-o ${PN} -v -x -mod=vendor . || die
+}
+
+src_install() {
+	dobin "${PN}"
+	dodoc README.md
+}
+
+# vim: filetype=ebuild


### PR DESCRIPTION
`doit`:
```
$ doit --release mark
INFO     Autogen: dev-util/ssh-compose (latest)                                                                                                                                                      
INFO     Created: ssh-compose-0.6.1.ebuild                                    
```

Test `emerge`:
```
>>> Installing (1 of 1) dev-util/ssh-compose-0.6.1::dev-kit
```
