### PR TITLE
Fix incorrect documentation path in libjpeg-turbo template

### DIFF
--- a/media-kit/curated/media-libs/templates/libjpeg-turbo.tmpl
+++ b/media-kit/curated/media-libs/templates/libjpeg-turbo.tmpl
@@ -98,7 +98,7 @@ src_install() {
 	einstalldocs
 
 	docinto html
-	dodoc -r "${S}"/doc/html/.
+	dodoc -r "${S}"/doc/turbojpeg/.
 
 	if use java; then
 		docinto html/java


### PR DESCRIPTION
Summary
========
* Updated the `dodoc` command to use the correct path for turbojpeg documentation instead of the previous html directory. This ensures the proper documentation is installed during the build process. 
* Closes: macaroni-os/mark-issues#238

```
~ # emerge -a media-libs/libjpeg-turbo

These are the packages that would be merged, in order:
... done!
[ebuild     U  ] media-libs/libjpeg-turbo-3.1.0 [3.0.4]

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) media-libs/libjpeg-turbo-3.1.0::media-kit
>>> Installing (1 of 1) media-libs/libjpeg-turbo-3.1.0::media-kit
>>> Recording media-libs/libjpeg-turbo in "world" favorites file...
>>> Jobs: 1 of 1 complete                           Load avg: 2.9, 23.0, 29.9
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.
```