### PR TITLE
Update kernel compatibility to version 6.12 in ZFS config

### DIFF
--- a/core-kit/curated/sys-fs/zfs/autogen.yaml
+++ b/core-kit/curated/sys-fs/zfs/autogen.yaml
@@ -1,7 +1,7 @@
 zfs_and_friends:
   generator: github-1
   defaults:
-    kernel_compat: "6.10"
+    kernel_compat: "6.12"
     github:
       user: openzfs
       repo: zfs


### PR DESCRIPTION
Summary
========
* Bumped the `kernel_compat` field from 6.10 to 6.12 in the ZFS autogen.yaml file. This ensures compatibility with the latest kernel version and keeps the configuration up to date.


Test Plan
========
* Doit
```
 ╰ $ doit
INFO     Autogen: sys-fs/zfs (latest)                                                                                                                                                                                        
INFO     Autogen: sys-fs/zfs-kmod (latest)                                                                                                                                                                                   
WARNING  WebSpider.get_existing_download:140597357156160 found active download for https://github.com/openzfs/zfs/tarball/9e6cb3f730bf39831c9b8acc6ce889668beab7ff                                                           
INFO     Download from https://github.com/openzfs/zfs/tarball/9e6cb3f730bf39831c9b8acc6ce889668beab7ff verified as valid tar.gz archive.                                                                                     
INFO     Created: ../zfs-kmod/zfs-kmod-2.2.7.ebuild                                                                                                                                                                          
INFO     Created: zfs-2.2.7.ebuild  
```
* Make it available in a own repo tree or by seeding into a local overlay
```
* Emerge it
```
~ # emerge --ask --verbose zfs zfs-kmod

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild   R    ] sys-fs/zfs-kmod-2.2.7::public-overlay [2.2.7::core-kit] USE="rootfs -custom-cflags -debug" 0 KiB
[ebuild   R    ] sys-fs/zfs-2.2.7:0/4::public-overlay [2.2.7:0/4::core-kit] USE="nls pam python rootfs split-usr -custom-cflags -debug (-kernel-builtin) -libressl -minimal -static-libs -test-suite" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8" 0 KiB

Total: 2 packages (2 reinstalls), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 2) sys-fs/zfs-kmod-2.2.7::public-overlay
>>> Installing (1 of 2) sys-fs/zfs-kmod-2.2.7::public-overlay
>>> Emerging (2 of 2) sys-fs/zfs-2.2.7::public-overlay
>>> Installing (2 of 2) sys-fs/zfs-2.2.7::public-overlay
>>> Jobs: 2 of 2 complete                           Load avg: 6.1, 4.8, 11.8

 * Messages for package sys-fs/zfs-kmod-2.2.7:

 * This version of OpenZFS includes support for new feature flags
 * that are incompatible with previous versions. GRUB2 support for
 * /boot with the new feature flags is not yet available.
 * Do *NOT* upgrade root pools to use the new feature flags.
 * Any new pools will be created with the new feature flags by default
 * and will not be compatible with older versions of ZFSOnLinux. To
 * create a newpool that is backward compatible wih GRUB2, use 
 * 
 * zpool create -d -o feature@async_destroy=enabled 
 * 	-o feature@empty_bpobj=enabled -o feature@lz4_compress=enabled
 * 	-o feature@spacemap_histogram=enabled
 * 	-o feature@enabled_txg=enabled 
 * 	-o feature@extensible_dataset=enabled -o feature@bookmarks=enabled
 * 	...
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.

```