### PR TITLE
dev-python/py Add du_pep517 to py dependencies in autogen.yaml

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -2118,6 +2118,7 @@ better_autogens_without_templates:
             - tomli-w
             - setuptools
     - py:
+        du_pep517: setuptools
         python_compat: python3+ pypy{,3}
         revision:
           1.11.0: 1


### PR DESCRIPTION
This change includes `du_pep517` with `setuptools` in the dependencies for `py` in autogen.yaml. It ensures proper handling of PEP 517 requirements during builds.
![image](https://github.com/user-attachments/assets/35451cb5-38fb-4636-ad74-0e867a740bf8)
