### PR TITLE
Pin media-gfx/inkscape-1.3.2

### DIFF
--- a/media-kit/curated/media-gfx/inkscape/autogen.yaml
+++ b/media-kit/curated/media-gfx/inkscape/autogen.yaml
@@ -1,7 +1,8 @@
 inkscape:
   generator: inkscape
   packages:
-    - inkscape
+    - inkscape:
+        version: '1.3.2'
 
 lockfile:
   defaults:

--- a/media-kit/curated/media-gfx/inkscape/generators/inkscape.py
+++ b/media-kit/curated/media-gfx/inkscape/generators/inkscape.py
@@ -16,13 +16,25 @@ async def generate(hub, **pkginfo):
 
     tarballs = [a.get('href') for a in soup if '.tar.' in a.contents[0] and not a.contents[0].endswith('sig')]
     versions = [(generic.parse(re.findall(regex, a)[0]), a) for a in tarballs if re.findall(regex, a)]
-    latest = max([v for v in versions if not v[0].is_prerelease])
 
-    artifact = hub.pkgtools.ebuild.Artifact(url=base_url+latest[1])
+    version = []
+    if 'version' in pkginfo:
+        version = [generic.parse(pkginfo['version'])]
+        del pkginfo['version']
+        try:
+            versions = dict(versions)
+            version.append(versions[version[0]])
+        except:
+            print(version[0], 'not found in:', versions)
+            return False
+    else:
+        version = max([v for v in versions if not v[0].is_prerelease])
+
+    artifact = hub.pkgtools.ebuild.Artifact(url=base_url+version[1])
 
     ebuild = hub.pkgtools.ebuild.BreezyBuild(
         **pkginfo,
-        version=latest[0],
+        version=version[0],
         artifacts=[artifact],
     )
     ebuild.push()


### PR DESCRIPTION
- Adds `media-gfx/inkscape` version value to `autogen.yaml` and sets it to `1.3.2`.
- Adds pinned version handling to `inkscape.py` generator.

Closes: macaroni-os/mark-issues#231