### PR TITLE
www-client/vivaldi Refactor version parsing in Vivaldi autogen script

### DIFF
--- a/browser-kit/curated/www-client/vivaldi/autogen.py
+++ b/browser-kit/curated/www-client/vivaldi/autogen.py
@@ -14,6 +14,13 @@ arches = {
 
 base_download_url = "https://downloads.vivaldi.com"
 
+def parse_versions(versions_script):
+	# Extract and clean up JSON part
+	json_part = versions_script.split("=", 1)[-1].strip()
+	if json_part.endswith(";"):
+		json_part = json_part[:-1]
+	return json.loads(json_part)
+
 
 async def generate_stable(hub, **pkginfo):
 	download_url = f"{base_download_url}/stable"
@@ -21,7 +28,7 @@ async def generate_stable(hub, **pkginfo):
 
 	versions_script = await hub.pkgtools.fetch.get_page(versions_script_url)
 
-	versions = json.loads(versions_script.split("=")[-1].strip())
+	versions = parse_versions(versions_script)
 	version = versions["vivaldi_version_number"]
 
 	artifacts = {}


### PR DESCRIPTION
Introduce `parse_versions` function to streamline and encapsulate the logic for extracting and cleaning JSON data from the fetched script. This improves readability and reusability in version handling.

(cherry picked from commit 65641b6bd5872dd6dd96b2964337fc948f60bcd9) (cherry picked from commit 40113ed12c1d7b5144ca0d3387cc6e8910d822b9)