### PR TITLE
[python-modules-kit] dev-python/urllib3 pinned v1.26.20

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -878,10 +878,8 @@ dev_python_compat_rule:
             distutils-r1_src_prepare
           }
     - urllib3:
-        version: 1.26.15
+        version: 1.26.20
         python_compat: python3+ pypy3
-        revision:
-          '1.26.15': '2'
         # https://github.com/urllib3/urllib3/issues/2680
         pydeps:
           py:all:build:


### PR DESCRIPTION
CVE-2023-43804, CVE-2023-45803

Closes: macaroni-os/mark-issues#248