### PR TITLE
[python-modules-kit] dev-python/cerberus - Fix pypi name

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -2294,8 +2294,7 @@ pep517_compliance_rule:
     - pyproject-metadata:
         pydeps:
           - packaging
-    - cerberus:
-        pypi_name: Cerberus
+    - cerberus
     - tomli-w:
         du_pep517: flit
     - boolean-py:


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#252