### PR TITLE
[dev-kit] app-misc/yq-go: Update template

### DIFF
--- a/dev-kit/curated/app-misc/yq-go/templates/yq-go.tmpl
+++ b/dev-kit/curated/app-misc/yq-go/templates/yq-go.tmpl
@@ -20,16 +20,16 @@ KEYWORDS="*"
 S="${WORKDIR}/{{github_user}}-{{github_repo}}-{{sha[:7]}}"
 
 DEPEND=""
-RDEPEND=">=dev-vcs/git-1.7.3"
+RDEPEND=""
 BDEPEND=">=dev-lang/go-1.16.14"
 
 src_compile() {
 	# The default yq go binary will conflict with python-modules-kit's app-misc/yq, which also has a yq executable installed to /usr/bin/yq
 	# For now until a decision is made regarding app-misc/yq, yq-go will be used as the binary name to avoid any collisions
-	go build -o bin/yq-go || die "compile failed"
+	go build -o bin/yq4 || die "compile failed"
 }
 
 src_install() {
-	dobin bin/yq-go
+	dobin bin/yq4
 	dodoc README.md
 }


### PR DESCRIPTION
* drop git from RDEPEND
* rename binary to *yq4* as used in Mottainai repo

Closes: macaroni-os/mark-issues#255