### PR TITLE
[core-hw-kit] sys-kernel/linux-firmware Fix newline escape in error message patching script

### DIFF
--- a/core-hw-kit/curated/sys-kernel/linux-firmware/files/linux-firmware-copy-firmware.patch
+++ b/core-hw-kit/curated/sys-kernel/linux-firmware/files/linux-firmware-copy-firmware.patch
@@ -38,9 +38,9 @@
 
  # Verify no broken symlinks
  if test "$(find "$destdir" -xtype l | wc -l)" -ne 0 ; then
--    err "Broken symlinks found:\\n$(find "$destdir" -xtype l)"
+-    err "Broken symlinks found:\n$(find "$destdir" -xtype l)"
 +    if  [ -z "${FIRMWARE_LIST}" ]; then
-+        err "Broken symlinks found:\\n$(find "$destdir" -xtype l)"
++        err "Broken symlinks found:\n$(find "$destdir" -xtype l)"
 +    fi
  fi
 


### PR DESCRIPTION
Summary
========
* Corrected improper newline escape sequences in error messages within the linux-firmware patch. This ensures consistent formatting and proper output display for error logs
* Closes: macaroni-os/mark-issues#260

Test Plan
* Emerge it
```
~ # emerge  linux-firmware

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] sys-kernel/linux-firmware-20250109 [20241210]

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) sys-kernel/linux-firmware-20250109::core-hw-kit
>>> Installing (1 of 1) sys-kernel/linux-firmware-20250109::core-hw-kit
>>> Jobs: 1 of 1 complete                           Load avg: 3.67, 2.60, 2.01
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.

```
