### PR TITLE
issue#267 [core-gl-kit] x11-base/xwayland-24.1.4 fails to merge

### DIFF
--- a/core-gl-kit/mark/x11-base/templates/xwayland.tmpl
+++ b/core-gl-kit/mark/x11-base/templates/xwayland.tmpl
@@ -12,19 +12,20 @@ SRC_URI="{{ src_uri }}"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="*"
-IUSE="rpc selinux unwind video_cards_nvidia xcsecurity"
+IUSE="rpc selinux unwind xcsecurity"
 
 DEPEND="
 	dev-libs/libbsd
 	dev-libs/openssl
 	>=dev-libs/wayland-1.21.0
 	>=dev-libs/wayland-protocols-1.30
+	gui-libs/egl-wayland
 	media-fonts/font-util
 	media-libs/libepoxy[X,egl(+)]
 	media-libs/libglvnd[X]
 	media-libs/mesa[X(+),egl(+),gbm(+)]
 	x11-apps/xkbcomp
-	>=x11-base/xorg-proto-2022.2
+	>=x11-base/xorg-proto-2024.1
 	>=x11-libs/libdrm-2.4.109
 	x11-libs/libXau
 	x11-libs/libxcvt
@@ -39,7 +40,6 @@ DEPEND="
 		>=sys-libs/libselinux-2.0.86
 	)
 	unwind? ( sys-libs/libunwind )
-	video_cards_nvidia? ( gui-libs/egl-wayland )
 "
 RDEPEND="${DEPEND}
 	selinux? ( sec-policy/selinux-xserver )
@@ -56,7 +56,6 @@ src_configure() {
 		$(meson_use selinux xselinux)
 		$(meson_use unwind libunwind)
 		$(meson_use xcsecurity)
-		$(meson_use video_cards_nvidia xwayland_eglstream)
 		-Ddpms=true
 		-Ddri3=true
 		-Ddtrace=false


### PR DESCRIPTION
xwayland_eglstream meson build option has been dropped upstream
xorg-proto dependency updated to 2024.1

NOTE: I do not have an nvidia card against which to test so further testing is required.

Bugs: macaroni-os/mark-issues#267