### PR TITLE
issue#268 [core-gl-kit] Add version x11-base/xorg-proto-2024.1

### DIFF
--- a/core-gl-kit/curated/x11-base/xorg-proto/autogen.py
+++ b/core-gl-kit/curated/x11-base/xorg-proto/autogen.py
@@ -88,6 +88,20 @@ async def generate(hub, **pkginfo):
 
 	template_args = dict(
 		**pkginfo,
+		version="2024.1",
+		GITLAB_GROUP="xorg/proto",
+		GITLAB_PROJ="xorgproto",
+		GITLAB_TAG="67469711055522b8adb2d795b01e7ba98cb8816c",
+	)
+	cpvr = "{cat}/{name}-{version}".format(**template_args)
+	url = "https://gitlab.freedesktop.org/{GITLAB_GROUP}/{GITLAB_PROJ}/-/archive/{GITLAB_TAG}/{GITLAB_PROJ}-{GITLAB_TAG}.tar.gz".format(**template_args)
+	final_name = "{name}-{version}.tar.gz".format(**template_args)
+	artifact = hub.pkgtools.ebuild.Artifact(url=url, final_name=final_name)
+
+	xorgproto_implementations.append((template_args, cpvr, artifact))
+
+	template_args = dict(
+		**pkginfo,
 		version="2023.2",
 		GITLAB_GROUP="xorg/proto",
 		GITLAB_PROJ="xorgproto",


### PR DESCRIPTION
updated xorg-proto autogen to include 2024.1

Bugs: macaroni-os/mark-issues#268