### PR TITLE
[core-kit] sys-fs/zfs Update ZFS autogen.yaml to remove version matching rules

### DIFF
--- a/core-kit/curated/sys-fs/zfs/autogen.yaml
+++ b/core-kit/curated/sys-fs/zfs/autogen.yaml
@@ -6,13 +6,6 @@ zfs_and_friends:
       user: openzfs
       repo: zfs
       query: releases
-      match: zfs-(2\.2\.[0-9].*)
-#      include:
-#        - prerelease
-#      transform:
-#        - kind: string
-#          match: '-rc'
-#          replace: '_rc'
   packages:
     - zfs
     - zfs-kmod


### PR DESCRIPTION
Summary
========
* Removed specific version matching patterns and commented-out sections in the ZFS autogen.yaml configuration. This streamlines the file and relies on default behavior for release handling.


Test Plan
========
* Doit
```
 ╰ $ doit
INFO     Autogen: sys-fs/zfs (latest)                                                                                                                                                                                        
INFO     Autogen: sys-fs/zfs-kmod (latest)                                                                                                                                                                                   
INFO     Created: ../zfs-kmod/zfs-kmod-2.3.0.ebuild                                                                                                                                                                          
INFO     Created: zfs-2.3.0.ebuild   
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
* Running it
```
~ # zfs version
zfs-2.3.0-r0-funtoo
zfs-kmod-2.3.0-r0-funtoo
```

