### PR TITLE
[python-modules-kit] missing rdepend on dev-python/yarl

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -2555,6 +2555,7 @@ ansible_deps_rule:
           S="${WORKDIR}/PyNaCl-${PV}"
         rdepend: |
           dev-libs/libsodium
+    - propcache
 
 yq_deps_rule:
   generator: pypi-compat-1

--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -2458,7 +2458,6 @@ dev_python_autogen_rule:
     - wcwidth
     - wstools:
         python_compat: python3+
-    - yarl
     - zope-component
     - zope-configuration
     - zope-deferredimport
@@ -2544,6 +2543,12 @@ ansible_deps_rule:
     - httplib2:
         pydeps:
           - pyparsing
+    - yarl:
+        pydeps:
+          py:all:
+            - idna >= 2.0
+            - propcache >= 0.2.0
+            - multidict >= 4.0
     - netaddr
     - pynacl:
         body: |


### PR DESCRIPTION
Related to https://github.com/macaroni-os/mark-issues/issues/269