### PR TITLE
[core-kit] sys-fs/zfs Update ZFS templates for MacaroniOS compatibility

### DIFF
--- a/core-kit/curated/sys-fs/zfs/autogen.yaml
+++ b/core-kit/curated/sys-fs/zfs/autogen.yaml
@@ -6,6 +6,7 @@ zfs_and_friends:
       user: openzfs
       repo: zfs
       query: releases
+      match: zfs-([0-9]\.[0-9]\.[0.9])
   packages:
     - zfs
     - zfs-kmod

--- a/core-kit/curated/sys-fs/zfs/templates/zfs-kmod.tmpl
+++ b/core-kit/curated/sys-fs/zfs/templates/zfs-kmod.tmpl
@@ -8,7 +8,7 @@ DESCRIPTION="Linux ZFS kernel module for sys-fs/zfs"
 HOMEPAGE="https://github.com/openzfs/zfs"
 
 MY_PV="${PV/_rc/-rc}"
-SRC_URI="{{artifacts[0].src_uri}}"
+SRC_URI="{{src_uri}}"
 KEYWORDS="*"
 ZFS_KERNEL_COMPAT="{{kernel_compat}}"
 
@@ -79,7 +79,7 @@ src_prepare() {
 	default
 
 	# Set module revision number
-	sed -i "s/\(Release:\)\(.*\)1/\1\2${PR}-funtoo/" META || die "Could not set Funtoo release"
+	sed -i "s/\(Release:\)\(.*\)1/\1\2${PR}-macaronios/" META || die "Could not set MacaroniOS release"
 }
 
 src_configure() {

--- a/core-kit/curated/sys-fs/zfs/templates/zfs.tmpl
+++ b/core-kit/curated/sys-fs/zfs/templates/zfs.tmpl
@@ -102,7 +102,7 @@ src_prepare() {
 	default
 
 	# Set revision number
-	sed -i "s/\(Release:\)\(.*\)1/\1\2${PR}-funtoo/" META || die "Could not set Gentoo release"
+	sed -i "s/\(Release:\)\(.*\)1/\1\2${PR}-macaronios/" META || die "Could not set MacaroniOS release"
 
 	if use python; then
 		pushd contrib/pyzfs >/dev/null || die


### PR DESCRIPTION
Summary
========
* Added pattern matching for ZFS release tags in autogen.yaml
* Replaced 'funtoo' references with 'macaronios' in zfs and zfs-kmod templates to reflect the target OS.
* Improved URI handling for zfs-kmod.