### PR TITLE
Update libimobiledevice autogen

### DIFF
--- a/core-hw-kit/curated/app-pda/libimobiledevice/autogen.yaml
+++ b/core-hw-kit/curated/app-pda/libimobiledevice/autogen.yaml
@@ -2,9 +2,9 @@ libimobiledevice:
   generator: github-1
   packages:
     - libimobiledevice:
-        version: 1.3.0_p20240330
+        version: 1.3.0_p20240401
         github:
           user: libimobiledevice
           repo: libimobiledevice
           query: snapshot
-          snapshot: 9649448434ab5c674d2cc11f76e69e6ee5e9dc09
+          snapshot: 1ec2c2c5e3609cc02b302bcbd79ed2872260d350


### PR DESCRIPTION
app-pda/libimobiledevice: update autogen snapshot to 2024-04-01 to include fixes that enable successful merge

Closes: macaroni-os/mark-issues#273