### PR TITLE
Pin linsdl2 autogen to version 2

### DIFF
--- a/media-kit/mark/media-libs/autogen.yaml
+++ b/media-kit/mark/media-libs/autogen.yaml
@@ -38,7 +38,7 @@ sdl2libs_rule:
           query: tags
           # An odd number in the minor version indicates a pre-release.
           # The latest one with an even number is the stable release.
-          select: release-\d+\.\d*[02468]\.\d+
+          select: release-2.\d*[02468]\.\d+
         tarball: release-{version}.tar.gz
     - sdl2-image:
         desc: Image decoding for many popular formats for SDL.


### PR DESCRIPTION
Updated autogen to find release numbers beginning with 2. I will raise a new issue to package libsdl3 separately.
Closes: macaroni-os/mark-issues#274