### PR TITLE
Add libsdl3 autogen

### DIFF
--- a/media-kit/mark/media-libs/autogen.yaml
+++ b/media-kit/mark/media-libs/autogen.yaml
@@ -30,6 +30,16 @@ sdl2libs_rule:
     github:
       user: libsdl-org
   packages:
+    - libsdl3:
+        desc: Simple Direct Media Layer
+        homepage: https://www.libsdl.org/
+        github:
+          repo: SDL
+          query: tags
+          # An odd number in the minor version indicates a pre-release.
+          # The latest one with an even number is the stable release.
+          select: release-\d+\.\d*[02468]\.\d+
+        tarball: release-{version}.tar.gz
     - libsdl2:
         desc: Simple Direct Media Layer
         homepage: https://www.libsdl.org/

--- a/media-kit/mark/media-libs/templates/libsdl3.tmpl
+++ b/media-kit/mark/media-libs/templates/libsdl3.tmpl
@@ -1,0 +1,165 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools cmake-utils flag-o-matic
+
+DESCRIPTION="{{ desc }}"
+HOMEPAGE="{{ homepage }}"
+SRC_URI="{{ src_uri }}"
+
+LICENSE="ZLIB"
+SLOT="0"
+KEYWORDS="*"
+
+IUSE="alsa aqua cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse cpu_flags_x86_sse2 custom-cflags dbus doc examples fcitx gles1 gles2 haptic ibus jack +joystick kms opengl oss pipewire pulseaudio sndio +sound static-libs +threads udev +video video_cards_vc4 vulkan wayland X xscreensaver"
+REQUIRED_USE="
+	alsa? ( sound )
+	fcitx? ( dbus )
+	gles1? ( video )
+	gles2? ( video )
+	haptic? ( joystick )
+	ibus? ( dbus )
+	jack? ( sound )
+	opengl? ( video )
+	pulseaudio? ( sound )
+	sndio? ( sound )
+	vulkan? ( video )
+	wayland? ( gles2 )
+	xscreensaver? ( X )"
+
+CDEPEND="
+	alsa? ( media-libs/alsa-lib )
+	dbus? ( sys-apps/dbus )
+	fcitx? ( app-i18n/fcitx )
+	gles1? ( media-libs/mesa[gles1] )
+	gles2? ( media-libs/mesa[gles2] )
+	ibus? ( app-i18n/ibus )
+	jack? ( virtual/jack )
+	kms? (
+		x11-libs/libdrm
+		media-libs/mesa[gbm(+)]
+	)
+	media-libs/nas
+	x11-libs/libXt
+	opengl? (
+		virtual/opengl
+		virtual/glu
+	)
+	pipewire? ( media-video/pipewire )
+	pulseaudio? ( media-sound/pulseaudio )
+	sndio? ( media-sound/sndio )
+	udev? ( virtual/libudev )
+	wayland? (
+		dev-libs/wayland
+		media-libs/mesa[egl(+),gles2,wayland]
+		x11-libs/libxkbcommon
+	)
+	X? (
+		x11-libs/libX11
+		x11-libs/libXcursor
+		x11-libs/libXext
+		x11-libs/libXfixes
+		x11-libs/libXi
+		x11-libs/libXrandr
+		xscreensaver? ( x11-libs/libXScrnSaver )
+	)"
+RDEPEND="${CDEPEND}
+	vulkan? ( media-libs/vulkan-loader )"
+DEPEND="${CDEPEND}
+	ibus? ( dev-libs/glib:2 )
+	vulkan? ( dev-util/vulkan-headers )
+	X? ( x11-base/xorg-proto )"
+BDEPEND="
+	virtual/pkgconfig
+	doc? (
+		app-doc/doxygen
+		media-gfx/graphviz
+	)
+	wayland? ( dev-util/wayland-scanner )"
+
+post_src_unpack() {
+	mv "${WORKDIR}"/libsdl-org-SDL-* "$S" || die
+}
+
+
+src_configure() {
+	use custom-cflags || strip-flags
+
+	local mycmakeargs=(
+		-DHAVE_FCITX=$(usex fcitx)
+		-DSDL_ALSA=$(usex alsa)
+		-DSDL_ALSA_SHARED=OFF
+		-DSDL_ALTIVEC=$(usex cpu_flags_ppc_altivec)
+		-DSDL_ASSEMBLY=ON
+		-DSDL_COCOA=$(usex aqua)
+		-DSDL_DBUS=$(usex dbus)
+		-DSDL_DIRECTX=OFF
+		-DSDL_DISKAUDIO=$(usex sound)
+		-DSDL_DUMMYAUDIO=$(usex sound)
+		-DSDL_DUMMYVIDEO=$(usex video)
+		-DSDL_EXAMPLES=$(usex examples)
+		-DSDL_HAPTIC=$(usex haptic)
+		-DSDL_IBUS=$(usex ibus)
+		-DSDL_INSTALL_DOCS=$(usex doc)
+		-DSDL_JACK=$(usex jack)
+		-DSDL_JACK_SHARED=OFF
+		-DSDL_JOYSTICK=$(usex joystick)
+		-DSDL_KMSDRM=$(usex kms)
+		-DSDL_KMSDRM_SHARED=OFF
+		-DSDL_LIBUDEV=$(usex udev)
+		-DSDL_MMX=$(usex cpu_flags_x86_mmx)
+		-DSDL_OPENGL=$(usex opengl)
+		-DSDL_OPENGLES=$(usex gles1)
+		-DSDL_OPENGLES=$(usex gles2)
+		-DSDL_OSS=$(usex oss)
+		-DSDL_PIPEWIRE=$(usex pipewire)
+		-DSDL_PIPEWIRE_SHARED=OFF
+		-DSDL_POWER=ON
+		-DSDL_PTHREADS=$(usex threads)
+		-DSDL_PULSEAUDIO=$(usex pulseaudio)
+		-DSDL_PULSEAUDIO_SHARED=OFF
+		-DSDL_RENDER_D3D11=OFF
+		-DSDL_RENDER_D3D12=OFF
+		-DSDL_RENDER_D3D=OFF
+		-DSDL_RPATH=OFF
+		-DSDL_RPI=$(usex video_cards_vc4)
+		-DSDL_SNDIO=$(usex sndio)
+		-DSDL_SNDIO_SHARED=OFF
+		-DSDL_SSE2=$(usex cpu_flags_x86_sse2)
+		-DSDL_SSE=$(usex cpu_flags_x86_sse)
+		-DSDL_STATIC=$(usex static-libs)
+		-DSDL_VIDEO=$(usex video)
+		-DSDL_VULKAN=$(usex vulkan)
+		-DSDL_WAYLAND=$(usex wayland)
+		-DSDL_WAYLAND_SHARED=OFF
+		-DSDL_X11=$(usex X)
+		-DSDL_X11_SHARED=OFF
+		-DSDL_X11_XCURSOR=$(usex X)
+		-DSDL_X11_XDBE=$(usex X)
+		-DSDL_X11_XFIXES=$(usex X)
+		-DSDL_X11_XINPUT=$(usex X)
+		-DSDL_X11_XRANDR=$(usex X)
+		-DSDL_X11_XSCRNSAVER=$(usex xscreensaver)
+		-DSDL_X11_XSHAPE=$(usex X)
+		-SDL_AUDIO=$(usex sound)
+	)
+
+	cmake-utils_src_configure
+}
+
+src_compile() {
+	if use doc; then
+		cd docs || die
+		doxygen || die
+	fi
+
+	cmake-utils_src_compile
+}
+
+src_install() {
+	dodoc {BUGS,WhatsNew}.txt CREDITS.md README.md docs/README*.md
+	use doc && dodoc -r docs/output/html/
+
+	cmake-utils_src_install
+}


### PR DESCRIPTION
libsdl3 section added to media-libs/autogen.yaml
libsdl3 template based on libsdl2 but use flags reviewed and updated and src_configure updated to reflect updated options

Closes: macaroni-os/mark-issues#279