### PR TITLE
[core-server-kit] net-libs/nghttp2 autogen for mark-devkit

### DIFF
--- a/core-server-kit/autogen.kit.d/net-base.yml
+++ b/core-server-kit/autogen.kit.d/net-base.yml
@@ -1,0 +1,65 @@
+net_libs_github:
+  generator: builtin-github
+  template:
+    engine: helm
+
+  defaults:
+    template: ../../templates/simple.tmpl
+    category: net-libs
+    github:
+      query: releases
+
+  packages:
+    - nghttp2:
+        github:
+          user: nghttp2
+        assets:
+          - name: "{{ .Values.github_user }}-{{ .Values.version }}.tar.xz"
+            matcher: "nghttp2-.*.tar.xz"
+        transform:
+          - kind: string
+            match: 'nghttp2 v'
+            replace: ''
+        vars:
+          homepage: https://nghttp2.org/
+          desc: HTTP/2 C Library
+          license: MIT
+          iuse: debug hpack-tools jemalloc static-libs +threads utils xml
+          rdepend: |
+            hpack-tools? ( >=dev-libs/jansson-2.5 )
+            jemalloc? ( dev-libs/jemalloc )
+            utils? (
+              >=dev-libs/libev-4.15
+              >=sys-libs/zlib-1.2.3
+              net-dns/c-ares:=
+            )
+            xml? ( >=dev-libs/libxml2-2.7.7:2 )
+
+          depend: |
+            ${RDEPEND}
+            dev-libs/openssl
+            virtual/pkgconfig
+
+          body: |
+            src_configure() {
+              local myeconfargs=(
+                --disable-examples
+                --disable-failmalloc
+                --disable-werror
+                $(use_enable debug)
+                $(use_enable hpack-tools)
+                $(use_enable static-libs static)
+                $(use_enable threads)
+                $(use_enable utils app)
+                $(use_with jemalloc)
+                $(use_with xml libxml2)
+              )
+              ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+            }
+
+            src_install() {
+              default
+              if ! use static-libs ; then
+                find "${ED}"/usr -name '*.la' -delete || die
+              fi
+            }

--- a/core-server-kit/merge.kit.d/net-base.yml
+++ b/core-server-kit/merge.kit.d/net-base.yml
@@ -28,8 +28,6 @@ target:
 
     - pkg: net-dialup/freeradius
 
-    - pkg: net-libs/nghttp2
-
     - pkg: net-misc/curl
     - pkg: net-misc/chrony
     - pkg: net-misc/wget

--- a/core-server-kit/merge.kit.d/net-base_autogen.yml
+++ b/core-server-kit/merge.kit.d/net-base_autogen.yml
@@ -1,0 +1,19 @@
+sources:
+# We need this to inherit the eclass used for kit cache JSON generation
+- name: "core-kit"
+  url: "https://github.com/macaroni-os/core-kit"
+  branch: "mark-unstable"
+
+target:
+  name: core-server-kit
+  url: "https://github.com/macaroni-os/core-server-kit"
+  branch: mark-unstable
+
+  fixups:
+    include:
+
+  atoms_defaults:
+    max_versions: 3
+
+  atoms:
+    - pkg: net-libs/nghttp2

--- a/templates/simple-github.tmpl
+++ b/templates/simple-github.tmpl
@@ -1,0 +1,45 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI={{ .Values.eapi | default "7" }}
+
+DESCRIPTION="{{ .Values.desc }}"
+HOMEPAGE="{{ .Values.homepage }}"
+SRC_URI="{{ .Values.src_uri }}"
+
+LICENSE="{{ .Values.license }}"
+SLOT="{{ .Values.slot | default 0 }}"
+KEYWORDS="{{ .Values.keywords | default "*" }}"
+
+{{- if .Values.restrict | default false }}
+RESTRICT="{{ .Values.restrict }}"
+{{- end }}
+
+{{- if .Values.depend | default false }}
+DEPEND="{{ regexReplaceAll "\\n" .Values.depend "\n\t" }}
+"
+{{- end }}
+{{- if .Values.bdepend | default false }}
+BDEPEND="{{ regexReplaceAll "\\n" .Values.bdepend "\n\t" }}
+"
+{{- end }}
+{{- if .Values.rdepend | default false }}
+RDEPEND="{{- regexReplaceAll "\\n" .Values.rdepend "\n\t" }}
+"
+{{- end }}
+{{- if .Values.pdepend | default false }}
+PDEPEND="{{ regexReplaceAll "\\n" .Values.pdepend "\n\t" }}
+"
+{{- end }}
+{{- if .Values.iuse | default false }}
+IUSE="{{ .Values.iuse }}"
+{{- end }}
+
+post_src_unpack() {
+	mv {{ .Values.github_user }}-{{ .Values.github_repo }}-* ${S}
+}
+
+{{ if .Values.body }}
+{{ regexReplaceAll "\\n\\s\\s" .Values.body "\n\t" }}
+{{ end }}
+
+# vim: filetype=ebuild

--- a/templates/simple.tmpl
+++ b/templates/simple.tmpl
@@ -1,0 +1,40 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI={{ .Values.eapi | default "7" }}
+
+DESCRIPTION="{{ .Values.desc }}"
+HOMEPAGE="{{ .Values.homepage }}"
+SRC_URI="{{ .Values.src_uri }}"
+
+LICENSE="{{ .Values.license }}"
+SLOT="{{ .Values.slot | default 0 }}"
+KEYWORDS="{{ .Values.keywords | default "*" }}"
+
+{{- if .Values.restrict | default false }}
+RESTRICT="{{ .Values.restrict }}"
+{{- end }}
+
+{{- if .Values.depend | default false }}
+DEPEND="{{ regexReplaceAll "\\n" .Values.depend "\n\t" }}
+"
+{{- end }}
+{{- if .Values.bdepend | default false }}
+BDEPEND="{{ regexReplaceAll "\\n" .Values.bdepend "\n\t" }}
+"
+{{- end }}
+{{- if .Values.rdepend | default false }}
+RDEPEND="{{- regexReplaceAll "\\n" .Values.rdepend "\n\t" }}
+"
+{{- end }}
+{{- if .Values.pdepend | default false }}
+PDEPEND="{{ regexReplaceAll "\\n" .Values.pdepend "\n\t" }}
+"
+{{- end }}
+{{- if .Values.iuse | default false }}
+IUSE="{{ .Values.iuse }}"
+{{- end }}
+{{ if .Values.body }}
+{{ regexReplaceAll "\\n\\s\\s" .Values.body "\n\t" }}
+{{ end }}
+
+# vim: filetype=ebuild


### PR DESCRIPTION
* removed reference to USE bindist of openssl no more available.
* removed USE cxx and libressl
* removed deprecated configure args

Closes: macaroni-os/mark-issues#283