### PR TITLE
[net-kit] net-vpn/strongswan - Remove /etc/ipsec.conf

### DIFF
--- a/net-kit/curated/net-vpn/strongswan/templates/strongswan.tmpl
+++ b/net-kit/curated/net-vpn/strongswan/templates/strongswan.tmpl
@@ -5,7 +5,7 @@ inherit linux-info user
 
 DESCRIPTION="{{ desc }}"
 HOMEPAGE="{{ homepage }}"
-SRC_URI="{{ artifacts[0].src_uri }}"
+SRC_URI="{{ src_uri }}"
 
 LICENSE="GPL-2 RSA DES"
 SLOT="0"
@@ -198,7 +198,6 @@ src_install() {
 	local dir_ugid
 	if use non-root; then
 		fowners ${UGID}:${UGID} \
-			/etc/ipsec.conf \
 			/etc/strongswan.conf
 
 		dir_ugid="${UGID}"
@@ -299,7 +298,7 @@ pkg_postinst() {
 		elog "For example (the default case):"
 		elog "/etc/sudoers:"
 		elog "  ipsec ALL=(ALL) NOPASSWD: SETENV: /usr/sbin/ipsec"
-		elog "Under the specific connection block in /etc/ipsec.conf:"
+		elog "Under the specific connection block:"
 		elog "  leftupdown=\"sudo -E ipsec _updown iptables\""
 		elog
 	fi


### PR DESCRIPTION
The file /etc/ipsec.conf is no more installed.
`swantctl` uses a different path for VPN configurations.

Closes: macaroni-os/mark-issues#290