### PR TITLE
[net-kit] net-vpn/strongswan - Autogen and fix openssl

### DIFF
--- a/net-kit/autogen.kit.d/base.yml
+++ b/net-kit/autogen.kit.d/base.yml
@@ -1,0 +1,28 @@
+net_vpn_dirlisting:
+  generator: builtin-dirlisting
+  template:
+    engine: helm
+
+  defaults:
+    template: ../../templates/simple.tmpl
+    category: net-vpn
+
+  packages:
+    - strongswan:
+        template: templates/strongswan.tmpl
+        dir:
+          url: https://download.strongswan.org/
+          matcher: "strongswan-.*.tar.bz2$"
+        assets:
+          - name: "{{ .Values.pn }}-{{ .Values.version }}.tar.bz2"
+        transform:
+          - kind: string
+            match: 'strongswan-'
+            replace: ''
+          - kind: string
+            match: '.tar.bz2'
+            replace: ''
+        vars:
+          desc: IPsec-based VPN solution, supporting IKEv1/IKEv2 and MOBIKE
+          homepage: https://www.strongswan.org/
+

--- a/net-kit/autogen.kit.d/templates/strongswan.tmpl
+++ b/net-kit/autogen.kit.d/templates/strongswan.tmpl
@@ -1,0 +1,271 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI={{ .Values.eapi | default "7" }}
+inherit user
+
+DESCRIPTION="{{ .Values.desc }}"
+HOMEPAGE="{{ .Values.homepage }}"
+SRC_URI="{{ .Values.src_uri }}"
+
+LICENSE="GPL-2 RSA DES"
+SLOT="0"
+KEYWORDS="*"
+IUSE="+caps curl +constraints debug dhcp eap farp gcrypt +gmp ldap mysql networkmanager +non-root +openssl selinux sqlite pam pkcs11"
+
+STRONGSWAN_PLUGINS_STD="gcm led lookip systime-fix unity vici"
+STRONGSWAN_PLUGINS_OPT_DISABLE="kdf"
+STRONGSWAN_PLUGINS_OPT="addrblock aesni blowfish bypass-lan ccm chapoly ctr error-notify forecast
+ha ipseckey newhope ntru padlock rdrand save-keys unbound whitelist
+xauth-noauth"
+for mod in $STRONGSWAN_PLUGINS_STD; do
+	IUSE="${IUSE} +strongswan_plugins_${mod}"
+done
+
+for mod in $STRONGSWAN_PLUGINS_OPT_DISABLE; do
+	IUSE="${IUSE} strongswan_plugins_${mod}"
+done
+
+for mod in $STRONGSWAN_PLUGINS_OPT; do
+	IUSE="${IUSE} strongswan_plugins_${mod}"
+done
+
+COMMON_DEPEND="
+	dev-libs/glib:2
+	gmp? ( >=dev-libs/gmp-4.1.5:= )
+	gcrypt? ( dev-libs/libgcrypt:= )
+	caps? ( sys-libs/libcap )
+	curl? ( net-misc/curl )
+	ldap? ( net-nds/openldap:= )
+	openssl? ( dev-libs/openssl )
+	mysql? ( dev-db/mysql-connector-c:= )
+	sqlite? ( >=dev-db/sqlite-3.3.1:3 )
+	networkmanager? ( net-misc/networkmanager )
+	pam? ( sys-libs/pam )
+	strongswan_plugins_unbound? ( net-dns/unbound:= net-libs/ldns:= )"
+
+DEPEND="${COMMON_DEPEND}
+	virtual/linux-sources
+	sys-kernel/linux-headers"
+
+RDEPEND="${COMMON_DEPEND}
+	virtual/logger
+	sys-apps/iproute2
+	!net-vpn/libreswan
+	selinux? ( sec-policy/selinux-ipsec )"
+
+UGID="ipsec"
+
+pkg_setup() {
+	if use non-root; then
+		enewgroup ${UGID}
+		enewuser ${UGID} -1 -1 -1 ${UGID}
+	fi
+}
+
+src_configure() {
+	local myconf=""
+
+	if use non-root; then
+		myconf="${myconf} --with-user=${UGID} --with-group=${UGID}"
+	fi
+
+	# If a user has already enabled db support, those plugins will
+	# most likely be desired as well. Besides they don't impose new
+	# dependencies and come at no cost (except for space).
+	if use mysql || use sqlite; then
+		myconf="${myconf} --enable-attr-sql --enable-sql"
+	fi
+
+	# strongSwan builds and installs static libs by default which are
+	# useless to the user (and to strongSwan for that matter) because no
+	# header files or alike get installed... so disabling them is safe.
+	if use pam && use eap; then
+		myconf="${myconf} --enable-eap-gtc"
+	else
+		myconf="${myconf} --disable-eap-gtc"
+	fi
+
+	for mod in $STRONGSWAN_PLUGINS_STD; do
+		if use strongswan_plugins_${mod}; then
+			myconf+=" --enable-${mod}"
+		fi
+	done
+
+	for mod in $STRONGSWAN_PLUGINS_OPT_DISABLE; do
+		if ! use strongswan_plugins_${mod}; then
+			myconf+=" --disable-${mod}"
+		fi
+	done
+
+	for mod in $STRONGSWAN_PLUGINS_OPT; do
+		if use strongswan_plugins_${mod}; then
+			myconf+=" --enable-${mod}"
+		fi
+	done
+
+	econf \
+		--disable-static \
+		--disable-systemd \
+		--enable-ikev1 \
+		--enable-ikev2 \
+		--enable-swanctl \
+		--enable-socket-dynamic \
+		--enable-cmd \
+		$(use_enable curl) \
+		$(use_enable constraints) \
+		$(use_enable ldap) \
+		$(use_enable debug leak-detective) \
+		$(use_enable dhcp) \
+		$(use_enable eap eap-sim) \
+		$(use_enable eap eap-sim-file) \
+		$(use_enable eap eap-simaka-sql) \
+		$(use_enable eap eap-simaka-pseudonym) \
+		$(use_enable eap eap-simaka-reauth) \
+		$(use_enable eap eap-identity) \
+		$(use_enable eap eap-md5) \
+		$(use_enable eap eap-aka) \
+		$(use_enable eap eap-aka-3gpp2) \
+		$(use_enable eap md4) \
+		$(use_enable eap eap-mschapv2) \
+		$(use_enable eap eap-radius) \
+		$(use_enable eap eap-tls) \
+		$(use_enable eap eap-ttls) \
+		$(use_enable eap xauth-eap) \
+		$(use_enable eap eap-dynamic) \
+		$(use_enable farp) \
+		$(use_enable gmp) \
+		$(use_enable gcrypt) \
+		$(use_enable mysql) \
+		$(use_enable networkmanager nm) \
+		$(use_enable openssl) \
+		$(use_enable pam xauth-pam) \
+		$(use_enable pkcs11) \
+		$(use_enable sqlite) \
+		$(use_with caps capabilities libcap) \
+		--with-piddir=/run \
+		${myconf}
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	doinitd "${FILESDIR}"/ipsec
+
+	local dir_ugid
+	if use non-root; then
+		fowners ${UGID}:${UGID} \
+			/etc/strongswan.conf
+
+		dir_ugid="${UGID}"
+	else
+		dir_ugid="root"
+	fi
+
+	diropts -m 0750 -o ${dir_ugid} -g ${dir_ugid}
+	dodir /etc/ipsec.d \
+		/etc/ipsec.d/aacerts \
+		/etc/ipsec.d/acerts \
+		/etc/ipsec.d/cacerts \
+		/etc/ipsec.d/certs \
+		/etc/ipsec.d/crls \
+		/etc/ipsec.d/ocspcerts \
+		/etc/ipsec.d/private \
+		/etc/ipsec.d/reqs
+
+	dodoc NEWS README TODO
+
+	# shared libs are used only internally and there are no static libs,
+	# so it's safe to get rid of the .la files
+	find "${D}" -name '*.la' -delete || die "Failed to remove .la files."
+}
+
+pkg_preinst() {
+	has_version "<net-vpn/strongswan-4.3.6-r1"
+	upgrade_from_leq_4_3_6=$(( !$? ))
+
+	has_version "<net-vpn/strongswan-4.3.6-r1[-caps]"
+	previous_4_3_6_with_caps=$(( !$? ))
+}
+
+pkg_postinst() {
+	if ! use openssl && ! use gcrypt; then
+		elog
+		elog "${PN} has been compiled without both OpenSSL and libgcrypt support."
+		elog "Please note that this might effect availability and speed of some"
+		elog "cryptographic features. You are advised to enable the OpenSSL plugin."
+	elif ! use openssl; then
+		elog
+		elog "${PN} has been compiled without the OpenSSL plugin. This might effect"
+		elog "availability and speed of some cryptographic features. There will be"
+		elog "no support for Elliptic Curve Cryptography (Diffie-Hellman groups 19-21,"
+		elog "25, 26) and ECDSA."
+	fi
+
+	if [[ $upgrade_from_leq_4_3_6 == 1 ]]; then
+		chmod 0750 "${ROOT}"/etc/ipsec.d \
+			"${ROOT}"/etc/ipsec.d/aacerts \
+			"${ROOT}"/etc/ipsec.d/acerts \
+			"${ROOT}"/etc/ipsec.d/cacerts \
+			"${ROOT}"/etc/ipsec.d/certs \
+			"${ROOT}"/etc/ipsec.d/crls \
+			"${ROOT}"/etc/ipsec.d/ocspcerts \
+			"${ROOT}"/etc/ipsec.d/private \
+			"${ROOT}"/etc/ipsec.d/reqs
+
+		ewarn
+		ewarn "The default permissions for /etc/ipsec.d/* have been tightened for"
+		ewarn "security reasons. Your system installed directories have been"
+		ewarn "updated accordingly. Please check if necessary."
+		ewarn
+
+		if [[ $previous_4_3_6_with_caps == 1 ]]; then
+			if ! use non-root; then
+				ewarn
+				ewarn "IMPORTANT: You previously had ${PN} installed without root"
+				ewarn "privileges because it was implied by the 'caps' USE flag."
+				ewarn "This has been changed. If you want ${PN} with user privileges,"
+				ewarn "you have to re-emerge it with the 'non-root' USE flag enabled."
+				ewarn
+			fi
+		fi
+	fi
+	if ! use caps && ! use non-root; then
+		ewarn
+		ewarn "You have decided to run ${PN} with root privileges and built it"
+		ewarn "without support for POSIX capability dropping. It is generally"
+		ewarn "strongly suggested that you reconsider- especially if you intend"
+		ewarn "to run ${PN} as server with a public ip address."
+		ewarn
+		ewarn "You should re-emerge ${PN} with at least the 'caps' USE flag enabled."
+		ewarn
+	fi
+	if use non-root; then
+		elog
+		elog "${PN} has been installed without superuser privileges (USE=non-root)."
+		elog "This imposes a few limitations mainly to the daemon 'charon' in"
+		elog "regards of the use of iptables."
+		elog
+		elog "Please carefully read: http://wiki.strongswan.org/projects/strongswan/wiki/ReducedPrivileges"
+		elog
+		elog "Thus if you require to specify a custom updown"
+		elog "script to charon which requires superuser privileges, you"
+		elog "can work around this limitation by using sudo to grant the"
+		elog "user \"ipsec\" the appropriate rights."
+		elog "For example (the default case):"
+		elog "/etc/sudoers:"
+		elog "  ipsec ALL=(ALL) NOPASSWD: SETENV: /usr/sbin/ipsec"
+		elog "Under the specific connection block:"
+		elog "  leftupdown=\"sudo -E ipsec _updown iptables\""
+		elog
+	fi
+	elog
+	elog "Make sure you have _all_ required kernel modules available including"
+	elog "the appropriate cryptographic algorithms. A list is available at:"
+	elog "  https://wiki.strongswan.org/projects/strongswan/wiki/KernelModules"
+	elog
+	elog "The up-to-date manual is available online at:"
+	elog "  https://wiki.strongswan.org/"
+	elog
+}
+
+# vim: filetype=ebuild

--- a/net-kit/merge.kit.d/base_autogen.yml
+++ b/net-kit/merge.kit.d/base_autogen.yml
@@ -1,0 +1,16 @@
+sources:
+# We need this to inherit the eclass used for kit cache JSON generation
+- name: "core-kit"
+  url: "https://github.com/macaroni-os/core-kit"
+  branch: "mark-unstable"
+
+target:
+  name: net-kit
+  url: "https://github.com/macaroni-os/net-kit"
+  branch: mark-unstable
+
+  atoms_defaults:
+    max_versions: 3
+
+  atoms:
+    - pkg: net-vpn/strongswan


### PR DESCRIPTION
The package `net-vpn/strongwan` is now autogen with `builtin-dirlisting` generator and doesn't reference anymore dev-libs/openssl[-bindist].

Closes: macaroni-os/mark-issues#288