### PR TITLE
[net-kit] net-dns/unbound autogen

### DIFF
--- a/net-kit/autogen.kit.d/base.yml
+++ b/net-kit/autogen.kit.d/base.yml
@@ -26,6 +26,33 @@ net_vpn_dirlisting:
           desc: IPsec-based VPN solution, supporting IKEv1/IKEv2 and MOBIKE
           homepage: https://www.strongswan.org/
 
+
+net_dns_dirlisting:
+  generator: builtin-dirlisting
+  template:
+    engine: helm
+
+  defaults:
+    files_dir: "{{ .Values.pn }}"
+    category: net-dns
+
+  packages:
+    - unbound:
+        template: templates/unbound.tmpl
+        dir:
+          url: https://nlnetlabs.nl/downloads/unbound/
+          matcher: "unbound-1..*.tar.gz$"
+          exclude: "rc"
+        assets:
+          - name: "{{ .Values.pn }}-{{ .Values.version }}.tar.gz"
+        transform:
+          - kind: string
+            match: 'unbound-'
+            replace: ''
+          - kind: string
+            match: '.tar.gz'
+            replace: ''
+
 net_wireless_noop:
   generator: builtin-noop
   template:

--- a/net-kit/autogen.kit.d/templates/unbound.tmpl
+++ b/net-kit/autogen.kit.d/templates/unbound.tmpl
@@ -1,0 +1,158 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+PYTHON_COMPAT=( python3+ )
+
+inherit autotools flag-o-matic multilib-minimal python-single-r1 systemd user
+
+MY_P=${PN}-${PV/_/}
+DESCRIPTION="A validating, recursive and caching DNS resolver"
+HOMEPAGE="https://unbound.net/ https://nlnetlabs.nl/projects/unbound/about/"
+SRC_URI="{{ .Values.src_uri }}"
+
+LICENSE="BSD GPL-2"
+SLOT="0" # ABI version of libunbound.so
+KEYWORDS="*"
+IUSE="debug dnscrypt dnstap +ecdsa ecs gost python redis +http2 selinux static-libs systemd test threads"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+CDEPEND=">=dev-libs/expat-2.1.0-r3
+	>=dev-libs/libevent-2.0.21:0=
+	dev-libs/openssl
+	dnscrypt? ( dev-libs/libsodium )
+	dnstap? (
+		dev-libs/fstrm
+		>=dev-libs/protobuf-c-1.0.2-r1
+	)
+	http2? ( net-libs/nghttp2 )
+	python? ( ${PYTHON_DEPS} )
+	redis? ( dev-libs/hiredis:= )"
+
+BDEPEND="virtual/pkgconfig"
+
+DEPEND="${CDEPEND}
+	python? ( dev-lang/swig )
+	systemd? ( sys-apps/systemd )"
+
+RDEPEND="${CDEPEND}
+	net-dns/dnssec-root
+	selinux? ( sec-policy/selinux-bind )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.5.7-trust-anchor-file.patch
+	"${FILESDIR}"/${PN}-1.6.3-pkg-config.patch
+	"${FILESDIR}"/${PN}-1.10.1-find-ar.patch
+)
+
+S=${WORKDIR}/${MY_P}
+
+pkg_setup() {
+	enewgroup unbound
+	enewuser unbound -1 -1 /etc/unbound unbound
+	# improve security on existing installs (bug #641042)
+	# as well as new installs where unbound homedir has just been created
+	if [[ -d "${ROOT}/etc/unbound" ]]; then
+		chown --no-dereference --from=unbound root "${ROOT}/etc/unbound"
+	fi
+
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable debug) \
+		$(use_enable gost) \
+		$(use_enable dnscrypt) \
+		$(use_enable dnstap) \
+		$(use_enable ecdsa) \
+		$(use_enable ecs subnet) \
+		$(use_enable redis cachedb) \
+		$(use_enable static-libs static) \
+		$(use_enable systemd) \
+		$(use_with python pythonmodule) \
+		$(use_with python pyunbound) \
+		$(use_with threads pthreads) \
+		$(use_with http2 libnghttp2) \
+		--disable-flto \
+		--with-username=unbound \
+		--disable-rpath \
+		--enable-event-api \
+		--enable-ipsecmod \
+		--enable-tfo-client \
+		--enable-tfo-server \
+		--with-libevent="${EPREFIX%/}"/usr \
+		$(usex redis --with-libhiredis="${EPREFIX%/}/usr" --without-libhiredis) \
+		--with-pidfile="${EPREFIX%/}"/run/unbound.pid \
+		--with-rootkey-file="${EPREFIX%/}"/etc/dnssec/root-anchors.txt \
+		--with-ssl="${EPREFIX%/}"/usr \
+		--with-libexpat="${EPREFIX%/}"/usr
+}
+
+src_install() {
+	use python && python_optimize
+
+	newconfd "${FILESDIR}"/unbound-r1.confd unbound
+
+	if use systemd ; then
+		systemd_dounit "${FILESDIR}"/unbound.service
+		systemd_dounit "${FILESDIR}"/unbound.socket
+		systemd_newunit "${FILESDIR}"/unbound_at.service "unbound@.service"
+		systemd_dounit "${FILESDIR}"/unbound-anchor.service
+	else
+		newinitd "${FILESDIR}"/unbound-r1.initd unbound
+	fi
+
+	dodoc doc/{README,CREDITS,TODO,Changelog,FEATURES}
+
+	# bug #315519
+	dodoc contrib/unbound_munin_
+
+	docinto selinux
+	dodoc contrib/selinux/*
+
+	exeinto /usr/share/${PN}
+	doexe contrib/update-anchor.sh
+
+	# create space for auto-trust-anchor-file...
+	keepdir /etc/unbound/var
+	# ... and point example config to it
+	sed -i \
+		-e '/# auto-trust-anchor-file:/s,/etc/dnssec/root-anchors.txt,/etc/unbound/var/root-anchors.txt,' \
+		"${ED%/}/etc/unbound/unbound.conf" || \
+		die
+
+	# Used to store cache data
+	keepdir /var/lib/${PN}
+	fowners root:unbound /var/lib/${PN}
+	fperms 0750 /var/lib/${PN}
+
+	find "${ED}" -name '*.la' -delete || die
+	if ! use static-libs ; then
+		find "${ED}" -name "*.a" -delete || die
+	fi
+}
+
+pkg_postinst() {
+	# make var/ writable by unbound
+	if [[ -d "${EROOT%/}/etc/unbound/var" ]]; then
+		chown --no-dereference --from=root unbound: "${EROOT%/}/etc/unbound/var"
+	fi
+
+	einfo ""
+	einfo "If you want unbound to automatically update the root-anchor file for DNSSEC validation"
+	einfo "set 'auto-trust-anchor-file: ${EROOT%/}/etc/unbound/var/root-anchors.txt' in ${EROOT%/}/etc/unbound/unbound.conf"
+	einfo "and run"
+	einfo ""
+	einfo "  su -s /bin/sh -c '${EROOT%/}/usr/sbin/unbound-anchor -a ${EROOT%/}/etc/unbound/var/root-anchors.txt' unbound"
+	einfo ""
+	einfo "as root to create it initially before starting unbound for the first time after enabling this."
+	einfo ""
+}
+
+# vim: filetype=ebuild

--- a/net-kit/autogen.kit.d/unbound/unbound-1.10.1-find-ar.patch
+++ b/net-kit/autogen.kit.d/unbound/unbound-1.10.1-find-ar.patch
@@ -1,0 +1,11 @@
+--- a/acx_nlnetlabs.m4
++++ b/acx_nlnetlabs.m4
+@@ -535,7 +535,7 @@ AC_CANONICAL_HOST
+ if echo "$host_os" | grep "sunos4" >/dev/null; then
+ 	lt_cv_sys_max_cmd_len=32750;
+ fi
+-AC_PATH_TOOL(AR, ar, [false])
++AC_CHECK_TOOL(AR, ar, [false])
+ if test $AR = false; then
+ 	AC_MSG_ERROR([Cannot find 'ar', please extend PATH to include it])
+ fi

--- a/net-kit/autogen.kit.d/unbound/unbound-1.5.7-trust-anchor-file.patch
+++ b/net-kit/autogen.kit.d/unbound/unbound-1.5.7-trust-anchor-file.patch
@@ -1,0 +1,18 @@
+To avoid below error messages like
+
+  [23109:0] error: Could not open autotrust file for writing, /etc/dnssec/root-anchors.txt: Permission denied
+
+set 'trust-anchor-file' to same value in 'auto-trust-anchor-file'.
+
+diff -ur unbound-1.5.7.orig/doc/example.conf.in unbound-1.5.7/doc/example.conf.in
+--- unbound-1.5.7.orig/doc/example.conf.in	2015-12-10 08:59:18.000000000 +0100
++++ unbound-1.5.7/doc/example.conf.in	2016-01-05 04:08:01.666760015 +0100
+@@ -378,7 +378,7 @@
+ 	# with several entries, one file per entry.
+ 	# Zone file format, with DS and DNSKEY entries.
+ 	# Note this gets out of date, use auto-trust-anchor-file please.
+-	# trust-anchor-file: ""
++	# trust-anchor-file: "@UNBOUND_ROOTKEY_FILE@"
+ 
+ 	# Trusted key for validation. DS or DNSKEY. specify the RR on a
+ 	# single line, surrounded by "". TTL is ignored. class is IN default.

--- a/net-kit/autogen.kit.d/unbound/unbound-1.6.3-pkg-config.patch
+++ b/net-kit/autogen.kit.d/unbound/unbound-1.6.3-pkg-config.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -95,6 +95,8 @@ AC_SUBST(LIBUNBOUND_CURRENT)
+ AC_SUBST(LIBUNBOUND_REVISION)
+ AC_SUBST(LIBUNBOUND_AGE)
+ 
++PKG_PROG_PKG_CONFIG
++
+ CFLAGS="$CFLAGS"
+ AC_AIX
+ if test "$ac_cv_header_minix_config_h" = "yes"; then

--- a/net-kit/autogen.kit.d/unbound/unbound-anchor.service
+++ b/net-kit/autogen.kit.d/unbound/unbound-anchor.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Update of the root trust anchor for DNSSEC validation
+After=network.target
+Before=nss-lookup.target
+Wants=nss-lookup.target
+Before=unbound.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/unbound-anchor
+
+[Install]
+WantedBy=multi-user.target

--- a/net-kit/autogen.kit.d/unbound/unbound-r1.confd
+++ b/net-kit/autogen.kit.d/unbound/unbound-r1.confd
@@ -1,0 +1,36 @@
+# /etc/conf.d/unbound
+
+# Configuration file
+#UNBOUND_CONFFILE="/etc/unbound/unbound.conf"
+
+# PID file
+# This is a fallback value which should NOT be changed. If you ever need
+# to change PID file, please change value in configuration file instead!
+#UNBOUND_PIDFILE="/run/unbound.pid"
+
+# You can use this configuration option to pass additional options to the
+# start-stop-daemon, see start-stop-daemon(8) for more details.
+# Per default we wait 1000ms after we have started the service to ensure
+# that the daemon is really up and running.
+#UNBOUND_SSDARGS="--wait 1000"
+
+# The termination timeout (start-stop-daemon parameter "retry") ensures
+# that the service will be terminated within a given time (25 + 5 seconds
+# per default) when you are stopping the service.
+#UNBOUND_TERMTIMEOUT="TERM/25/KILL/5"
+
+# Options to unbound
+# See unbound(8) for more details
+# Notes:
+# * Do not specify another CONFIGFILE but use the variable above to change the location
+#UNBOUND_OPTS=""
+
+# If you want to preserve unbound's cache, set the following variable to
+# a non-zero value. In this case unbound's cache will be dumped to disk
+# before shutdown and loaded right after start.
+# To be able to dump and load cache you have to set up keys (use `unbound-control-setup`)
+# and need to set 'control-enable: yes' in your configuration!
+# WARNING: If you don't know what you are doing you should NOT use this
+#          feature. Loading the cache with old or wrong data can result in
+#          old or wrong data being returned to clients.
+#UNBOUND_PRESERVE_CACHE=""

--- a/net-kit/autogen.kit.d/unbound/unbound-r1.initd
+++ b/net-kit/autogen.kit.d/unbound/unbound-r1.initd
@@ -1,0 +1,137 @@
+#!/sbin/openrc-run
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+UNBOUND_BINARY=${UNBOUND_BINARY:-"/usr/sbin/unbound"}
+UNBOUND_CACHEFILE=${UNBOUND_CACHEFILE:-"/var/lib/unbound/${SVCNAME}.cache"}
+UNBOUND_CHECKCONF=${UNBOUND_CHECKCONF:-"/usr/sbin/unbound-checkconf"}
+UNBOUND_CONFFILE=${UNBOUND_CONFFILE:-"/etc/unbound/${SVCNAME}.conf"}
+UNBOUND_CONTROL=${UNBOUND_CONTROL:-"/usr/sbin/unbound-control"}
+UNBOUND_PIDFILE=${UNBOUND_PIDFILE:-"/run/unbound.pid"}
+UNBOUND_SSDARGS=${UNBOUND_SSDARGS:-"--wait 1000"}
+UNBOUND_TERMTIMEOUT=${UNBOUND_TERMTIMEOUT:-"TERM/25/KILL/5"}
+UNBOUND_OPTS=${UNBOUND_OPTS:-""}
+UNBOUND_LOAD_CACHE_TIMEOUT=${UNBOUND_LOAD_CACHE_TIMEOUT:-"30"}
+
+getconfig() {
+	local key="$1"
+	local value_default="$2"
+	local value=
+
+	if service_started ; then
+		value="$(service_get_value "${key}")"
+	fi
+
+	if [ -z "${value}" ] && [ -n "${UNBOUND_CONFFILE}" ] && [ -r "${UNBOUND_CONFFILE}" ] ; then
+		value=$("${UNBOUND_CHECKCONF}" -o ${key} "${UNBOUND_CONFFILE}")
+	fi
+
+	if [ -z "${value}" ] ; then
+		# Value not explicitly set in the configfile or configfile does not exist
+		# or is not readable
+		echo "${value_default}"
+	else
+		echo "${value}"
+	fi
+
+	return 0
+}
+
+command=${UNBOUND_BINARY}
+command_args="${UNBOUND_OPTS} -c \"${UNBOUND_CONFFILE}\""
+start_stop_daemon_args="${UNBOUND_SSDARGS}"
+pidfile="$(getconfig pidfile /run/unbound.pid)"
+retry="${UNBOUND_TERMTIMEOUT}"
+
+required_files="${UNBOUND_CONFFILE}"
+
+name="unbound daemon"
+extra_commands="configtest"
+extra_started_commands="reload save_cache"
+description="unbound is a Domain Name Server (DNS) that is used to resolve host names to IP address."
+description_configtest="Run syntax tests for configuration files only."
+description_reload="Kills all children and reloads the configuration."
+description_save_cache="Saves the current cache to disk."
+
+depend() {
+	use net logger
+	provide dns
+	after auth-dns
+}
+
+configtest() {
+	local _config_status=
+
+	ebegin "Checking ${SVCNAME} configuration"
+	"${UNBOUND_CHECKCONF}" "${UNBOUND_CONFFILE}" 1>/dev/null 2>&1
+	_config_status=$?
+
+	if [ ${_config_status} -ne 0 ] ; then
+		# Run command again but this time we will show the output
+		# Ugly, but ...
+		"${UNBOUND_CHECKCONF}" "${UNBOUND_CONFFILE}"
+	else
+		if [ -n "${UNBOUND_PRESERVE_CACHE}" ] ; then
+			local _is_control_enabled=$(getconfig control-enable no)
+			if [ "${_is_control_enabled}" != "yes" ] ; then
+				eerror "Cannot preserve cache: control-enable is 'no' in the config file!"
+				_config_status=2
+			fi
+		fi
+	fi
+
+	eend ${_config_status} "failed, please correct errors above"
+}
+
+save_cache() {
+	if [ "${RC_CMD}" != "restart" ] ; then
+		UNBOUND_PRESERVE_CACHE=1 configtest || return 1
+	fi
+
+	ebegin "Saving cache to '${UNBOUND_CACHEFILE}'"
+	${UNBOUND_CONTROL} -c "${UNBOUND_CONFFILE}" dump_cache > "${UNBOUND_CACHEFILE}"
+	eend $?
+}
+
+start_pre() {
+	if [ "${RC_CMD}" != "restart" ] ; then
+		configtest || return 1
+	fi
+}
+
+start_post() {
+	if [ -n "${UNBOUND_PRESERVE_CACHE}" ] ; then
+		if [ -s "${UNBOUND_CACHEFILE}" ] ; then
+			ebegin "Loading cache from '${UNBOUND_CACHEFILE}'"
+			# Loading cache can fail which would block this runscript.
+			# Using `timeout` from coreutils will be our safeguard ...
+			timeout -k 5 ${UNBOUND_LOAD_CACHE_TIMEOUT} ${UNBOUND_CONTROL} -q -c "${UNBOUND_CONFFILE}" load_cache < "${UNBOUND_CACHEFILE}"
+			eend $?
+		else
+			ewarn "Loading cache from '${UNBOUND_CACHEFILE}' skipped: File does not exists or is empty!"
+		fi
+	fi
+
+	# It is not a fatal error if preserved cache could not be loaded
+	return 0
+}
+
+stop_pre() {
+	if [ "${RC_CMD}" = "restart" ] ; then
+		configtest || return 1
+	fi
+
+	if [ -n "${UNBOUND_PRESERVE_CACHE}" ] ; then
+		save_cache
+	fi
+
+	# It is not a fatal error if cache cannot be preserved
+	return 0
+}
+
+reload() {
+	configtest || return 1
+	ebegin "Reloading ${SVCNAME}"
+	start-stop-daemon --signal HUP --pidfile "${pidfile}"
+	eend $?
+}

--- a/net-kit/autogen.kit.d/unbound/unbound.service
+++ b/net-kit/autogen.kit.d/unbound/unbound.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Unbound recursive Domain Name Server
+After=network.target
+Before=nss-lookup.target
+Wants=nss-lookup.target
+
+[Service]
+ExecStartPre=/usr/sbin/unbound-checkconf
+ExecStart=/usr/sbin/unbound -d
+
+[Install]
+WantedBy=multi-user.target

--- a/net-kit/autogen.kit.d/unbound/unbound.socket
+++ b/net-kit/autogen.kit.d/unbound/unbound.socket
@@ -1,0 +1,5 @@
+[Socket]
+ListenDatagram=127.0.0.1:1153
+ListenStream=127.0.0.1:1153
+[Install]
+WantedBy=sockets.target

--- a/net-kit/autogen.kit.d/unbound/unbound_at.service
+++ b/net-kit/autogen.kit.d/unbound/unbound_at.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Unbound recursive Domain Name Server
+After=network.target
+Before=nss-lookup.target
+Wants=nss-lookup.target
+
+[Service]
+Type=simple
+ExecStartPre=/usr/sbin/unbound-checkconf /etc/unbound/%i.conf
+ExecStart=/usr/sbin/unbound -d -c /etc/unbound/%i.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/net-kit/merge.kit.d/base_autogen.yml
+++ b/net-kit/merge.kit.d/base_autogen.yml
@@ -13,6 +13,8 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: net-dns/unbound
+
     - pkg: net-vpn/strongswan
 
     - pkg: net-wireless/wpa_supplicant


### PR DESCRIPTION
Add `builtin-dirlisting` specs and remove
reference to dev-libs/openssl[-bindist].
Added `http2` USE flag.

Closes: macaroni-os/mark-issues#287