### PR TITLE
[core-server-kit] sys-cluster/glusterfs - mark autogen + opensslv3 fix

### DIFF
--- a/core-server-kit/autogen.kit.d/glusterfs/50glusterfs-mode-gentoo.el
+++ b/core-server-kit/autogen.kit.d/glusterfs/50glusterfs-mode-gentoo.el
@@ -1,0 +1,5 @@
+
+;;; puppet-mode site-lisp configuration
+
+(add-to-list 'load-path "@SITELISP@")
+(autoload 'glusterfs-mode "glusterfs-mode" "Major mode for editing glusterfs manifests")

--- a/core-server-kit/autogen.kit.d/glusterfs/glusterd-10.2-r2.initd
+++ b/core-server-kit/autogen.kit.d/glusterfs/glusterd-10.2-r2.initd
@@ -1,0 +1,32 @@
+#!/sbin/openrc-run
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Gluster elastic volume management daemon"
+command="/usr/sbin/glusterd"
+pidfile="/run/${SVCNAME}.pid"
+command_args="-N"
+
+command_background="yes"
+
+depend() {
+	need net
+	before netmount
+}
+
+start_pre() {
+	# Ensure that the GlusterFS auxiliary mount parent directory exists
+	checkpath --directory --owner gluster:gluster --mode 0775 /run/gluster
+}
+
+start_post() {
+	local c=0
+	ebegin "Waiting for glusterd to start up"
+	while ! /usr/sbin/gluster volume list >/dev/null 2>&1 && [ "${c}" -lt "${glusterd_max_wait_start-60}" ]; do
+		c=$(( c+1 ))
+	done
+	[ "${c}" -lt "${glusterd_max_wait_start-60}" ]
+	eend $?
+
+	return 0
+}

--- a/core-server-kit/autogen.kit.d/glusterfs/glusterfs-11.0-extras-defer-invoking-of-gluster-volume-set-help.patch
+++ b/core-server-kit/autogen.kit.d/glusterfs/glusterfs-11.0-extras-defer-invoking-of-gluster-volume-set-help.patch
@@ -1,0 +1,85 @@
+From 26126dd1467fc40af372b9f2ba6ab167e5b9f309 Mon Sep 17 00:00:00 2001
+From: Jaco Kroon <jaco@uls.co.za>
+Date: Mon, 28 Aug 2023 09:54:47 +0200
+Subject: [PATCH] extras: defer invoking of gluster volume set help as late as
+ we can.
+
+---
+ extras/command-completion/gluster.bash | 44 +++++++++++++++++++-------
+ 1 file changed, 32 insertions(+), 12 deletions(-)
+
+diff --git a/extras/command-completion/gluster.bash b/extras/command-completion/gluster.bash
+index 70f8e19558..a096b62890 100644
+--- a/extras/command-completion/gluster.bash
++++ b/extras/command-completion/gluster.bash
+@@ -1,15 +1,5 @@
+ #!/bin/bash
+ 
+-if pidof glusterd > /dev/null 2>&1; then
+-        GLUSTER_SET_OPTIONS="
+-        $(for token in `gluster volume set help 2>/dev/null | grep "^Option:" | cut -d ' ' -f 2`
+-        do
+-                echo "{$token},"
+-        done)
+-        "
+-        GLUSTER_RESET_OPTIONS="$GLUSTER_SET_OPTIONS"
+-fi
+-
+ GLUSTER_TOP_SUBOPTIONS1="
+         {nfs},
+         {brick},
+@@ -161,12 +151,14 @@ GLUSTER_VOLUME_OPTIONS="
+                 },
+                 {reset
+                         {__VOLNAME
+-                                [ $GLUSTER_RESET_OPTIONS ]
++                                {__VOLOPTIONS
++                                },
+                         }
+                 },
+                 {set
+                         {__VOLNAME
+-                                [ $GLUSTER_SET_OPTIONS ]
++                                {__VOLOPTIONS
++                                },
+                         }
+                 },
+                 {start
+@@ -280,6 +272,34 @@ __VOLNAME ()
+         return 0
+ }
+ 
++__VOLOPTIONS()
++{
++        local zero=0
++        local ret=0
++        local cur_word="$2"
++        local list=""
++
++        if [ "X$1" == "X" ]; then
++                return
++
++        elif [ "$1" == "match" ]; then
++                return 0
++
++        elif [ "$1" == "complete" ]; then
++                if ! pidof glusterd > /dev/null 2>&1; then
++                        list='';
++                else
++                        list=`gluster volume set help 2>/dev/null | grep "^Option:" | cut -d ' ' -f 2`
++                fi
++        else
++                return 0
++        fi
++
++        func_return=`echo $(compgen -W "$list" -- $cur_word)`
++
++        return 0
++}
++
+ _gluster_throw () {
+ #echo $1 >&2
+         COMPREPLY=''
+-- 
+2.41.0
+

--- a/core-server-kit/autogen.kit.d/glusterfs/glusterfs-11.0-fix-crash.patch
+++ b/core-server-kit/autogen.kit.d/glusterfs/glusterfs-11.0-fix-crash.patch
@@ -1,0 +1,16 @@
+# https://bugs.gentoo.org/911588
+# https://github.com/gluster/glusterfs/issues/4192
+# https://github.com/gluster/glusterfs/pull/4196
+diff --git a/libglusterfs/src/glusterfs/mem-pool.h b/libglusterfs/src/glusterfs/mem-pool.h
+index 46f764f56e5..416b7ddf1e3 100644
+--- a/libglusterfs/src/glusterfs/mem-pool.h
++++ b/libglusterfs/src/glusterfs/mem-pool.h
+@@ -297,7 +297,7 @@ typedef struct per_thread_pool_list {
+      * in the implementation code so we just make it a single-element array
+      * here.
+      */
+-    per_thread_pool_t pools[];
++    per_thread_pool_t pools[1];
+ } per_thread_pool_list_t;
+ 
+ /* actual pool structure, shared between different mem_pools */

--- a/core-server-kit/autogen.kit.d/glusterfs/glusterfs.confd
+++ b/core-server-kit/autogen.kit.d/glusterfs/glusterfs.confd
@@ -1,0 +1,6 @@
+#glusterfsd_mountpoint=""
+#glusterfsd_log=""
+#glusterfsd_vol=""
+#glusterfsd_port=""
+#glusterfsd_transport=""
+#glusterfsd_opts=""

--- a/core-server-kit/autogen.kit.d/glusterfs/glusterfs.logrotate
+++ b/core-server-kit/autogen.kit.d/glusterfs/glusterfs.logrotate
@@ -1,0 +1,34 @@
+# Rotate client logs
+/var/log/glusterfs/*.log {
+  weekly
+  rotate 52
+  missingok
+
+  # compress the logs, but from the .2 onwards
+  compress
+  delaycompress
+  notifempty
+
+  sharedscripts
+  postrotate
+  /usr/bin/killall -HUP glusterfs > /dev/null 2>&1 || true
+  /usr/bin/killall -HUP glusterd > /dev/null 2>&1 || true
+  endscript
+}
+
+# Rotate server logs
+/var/log/glusterfs/bricks/*.log {
+  weekly
+  rotate 52
+  missingok
+
+  # compress the logs, but from the .2 onwards
+  compress
+  delaycompress
+  notifempty
+
+  sharedscripts
+  postrotate
+  /usr/bin/killall -HUP glusterfsd > /dev/null 2>&1 || true
+  endscript
+}

--- a/core-server-kit/autogen.kit.d/glusterfs/glusterfs.vim
+++ b/core-server-kit/autogen.kit.d/glusterfs/glusterfs.vim
@@ -1,0 +1,8 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+
+" GlusterFS Volume files
+au BufNewFile,BufRead *.vol
+    \     set filetype=glusterfs

--- a/core-server-kit/autogen.kit.d/glusterfs/glusterfsd-10.2.initd
+++ b/core-server-kit/autogen.kit.d/glusterfs/glusterfsd-10.2.initd
@@ -1,0 +1,121 @@
+#!/sbin/openrc-run
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+if [ "${SVCNAME}" != "glusterfs" ]
+then
+	GLUSTERFS_NAME="${SVCNAME#glusterfs.}"
+else
+	GLUSTERFS_NAME="glusterfs"
+fi
+
+GLUSTERFS_PIDFILE="/var/run/${SVCNAME}.pid"
+
+eval 'GLUSTERFS_LOGFILE="${'${GLUSTERFS_NAME}'_log:-/var/log/glusterfs/'${GLUSTERFS_NAME}'.log}"'
+eval 'GLUSTERFS_VOLFILE="${'${GLUSTERFS_NAME}'_vol:-/etc/glusterfs/'${GLUSTERFS_NAME}'.vol}"'
+eval 'GLUSTERFS_SERVER="${'${GLUSTERFS_NAME}'_server}"'
+eval 'GLUSTERFS_PORT="${'${GLUSTERFS_NAME}'_port:-6996}"'
+eval 'GLUSTERFS_TRANSPORT="${'${GLUSTERFS_NAME}'_transport:-socket}"'
+eval 'GLUSTERFS_OPTS="${'${GLUSTERFS_NAME}'_opts}"'
+eval 'GLUSTERFS_MOUNTPOINT="${'${GLUSTERFS_NAME}'_mountpoint}"'
+
+depend() {
+	need net 
+	[ -n "${GLUSTERFS_MOUNTPOINT}" ] && need fuse
+	use dns
+	before netmount
+	after firewall ntp-client ntpd
+}
+
+checkconfig() {
+	if [ -z "${GLUSTERFS_NAME}" ]
+	then
+		eerror "The service name is not properly formatted."
+		return 1
+	fi
+
+	if [ -z "${GLUSTERFS_SERVER}" ]
+	then
+		if [ -z "${GLUSTERFS_VOLFILE}" ]
+		then
+			eerror "No GlusterFS volume file source has been defined.  Edit /etc/conf.d/glusterfs"
+			eerror "and configure a volume file source for ${SVCNAME}."
+			return 1
+		else
+			if [ ! -f "${GLUSTERFS_VOLFILE}" ]
+			then
+				eerror "Cannot find volume file: ${GLUSTERFS_VOLFILE}"
+				return 1
+			fi
+		fi
+	fi
+
+	if [ -n "${GLUSTERFS_MOUNTPOINT}" -a ! -d "${GLUSTERFS_MOUNTPOINT}" ]
+	then
+		eerror "The mountpoint ${GLUSTERFS_MOUNTPOINT} does not exist."
+		return 1
+	fi
+}
+
+start() {
+	local status daemon
+
+	checkconfig || return 1
+
+	ebegin "Starting GlusterFS (${SVCNAME})"
+	eindent
+
+	if [ -z "${GLUSTERFS_MOUNTPOINT}" ]
+	then
+		einfo "Starting in server mode ..."
+		daemon="glusterfsd"
+	else
+		einfo "Starting in client mode. Mounting filesystem ..."
+		daemon="glusterfs"
+	fi
+
+	if [ -n "${GLUSTERFS_SERVER}" ]
+	then
+		einfo "Using server supplied volume file"
+		start-stop-daemon --start --pidfile ${GLUSTERFS_PIDFILE} \
+			--exec /usr/sbin/${daemon} -- \
+			--pid-file=${GLUSTERFS_PIDFILE} \
+			--log-file=${GLUSTERFS_LOGFILE} \
+			--volfile-server=${GLUSTERFS_SERVER} \
+			--volfile-server-port=${GLUSTERFS_PORT} \
+			--volfile-server-transport=${GLUSTERFS_TRANSPORT} \
+			${GLUSTERFS_OPTS} ${GLUSTERFS_MOUNTPOINT}
+		status="$?"
+	else
+		einfo "Using local volume file"
+		start-stop-daemon --start --pidfile ${GLUSTERFS_PIDFILE} \
+			--exec /usr/sbin/${daemon} -- \
+			--pid-file=${GLUSTERFS_PIDFILE} \
+			--log-file=${GLUSTERFS_LOGFILE} \
+			--volfile=${GLUSTERFS_VOLFILE} \
+			${GLUSTERFS_OPTS} ${GLUSTERFS_MOUNTPOINT}
+		status="$?"
+	fi
+
+	eoutdent
+	eend ${status}
+}
+
+stop() {
+	local status
+
+	ebegin "Stopping GlusterFS (${SVCNAME})"
+	eindent
+	if [ -z "${GLUSTERFS_MOUNTPOINT}" ]
+	then
+		einfo "Stopping server process ..."
+		start-stop-daemon --stop --pidfile ${GLUSTERFS_PIDFILE}
+		status="$?"
+	else
+		einfo "Unmounting ${GLUSTERFS_MOUNTPOINT} ..."
+		umount "${GLUSTERFS_MOUNTPOINT}"
+		status="$?"
+	fi
+	eoutdent
+	eend ${status}
+}

--- a/core-server-kit/autogen.kit.d/net-base.yml
+++ b/core-server-kit/autogen.kit.d/net-base.yml
@@ -63,3 +63,29 @@ net_libs_github:
                 find "${ED}"/usr -name '*.la' -delete || die
               fi
             }
+
+sys_cluster_github:
+  generator: builtin-github
+  template:
+    engine: j2cli
+
+  defaults:
+    category: sys-cluster
+    files_dir: "{{ .Values.pn }}"
+    github:
+      query: tags
+
+  packages:
+    - glusterfs:
+        github:
+          user: gluster
+        exclude:
+          - '.*dev$'
+          - '.*alpha|.*rc.*'
+
+        vars:
+          desc: GlusterFS is a powerful network/cluster filesystem
+          homepage: https://www.gluster.org/ https://github.com/gluster/glusterfs/
+          patches:
+            - 11.0-extras-defer-invoking-of-gluster-volume-set-help.patch
+

--- a/core-server-kit/autogen.kit.d/templates/glusterfs.tmpl
+++ b/core-server-kit/autogen.kit.d/templates/glusterfs.tmpl
@@ -1,0 +1,223 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3+ )
+
+inherit autotools elisp-common python-single-r1 user tmpfiles bash-completion-r1
+
+DESCRIPTION="{{ desc }}"
+HOMEPAGE="{{ homepage }}"
+SRC_URI="{{ src_uri }}"
+
+LICENSE="|| ( GPL-2 LGPL-3+ )"
+SLOT="0/${PV%%.*}"
+KEYWORDS="*"
+
+IUSE="debug emacs +fuse georeplication ipv6 rsyslog selinux static-libs tcmalloc test +uring xml"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}
+	georeplication? ( xml )"
+
+# the tests must be run as root
+RESTRICT="test"
+
+{%- if patches %}
+PATCHES=(
+{%- for patch in patches %}
+	"${FILESDIR}"/"${PN}-{{ patch }}"
+{%- endfor %}
+)
+{%- endif %}
+
+# sys-apps/util-linux is required for libuuid
+RDEPEND="
+	dev-libs/libaio
+	dev-libs/openssl
+	net-libs/libtirpc:=
+	net-libs/rpcsvc-proto
+	dev-libs/userspace-rcu:=
+	sys-apps/util-linux
+	sys-libs/readline:=
+	${PYTHON_DEPS}
+
+	!elibc_glibc? ( sys-libs/argp-standalone )
+	emacs? ( >=app-editors/emacs-23.1:* )
+	fuse? ( >=sys-fs/fuse-2.7.0:0 )
+	selinux? ( sec-policy/selinux-glusterfs )
+	tcmalloc? ( dev-util/google-perftools )
+	uring? ( sys-libs/liburing:= )
+	xml? ( dev-libs/libxml2 )
+"
+DEPEND="
+	${RDEPEND}
+	virtual/acl
+	test? (
+		dev-util/cmocka
+		app-benchmarks/dbench
+		dev-libs/xxhash
+		dev-vcs/git
+		virtual/perl-Test-Harness
+		dev-libs/yajl
+		sys-fs/xfsprogs
+		sys-apps/attr
+	)
+"
+BDEPEND="
+	sys-devel/bison
+	sys-devel/flex
+	virtual/pkgconfig
+"
+
+DOCS=( AUTHORS ChangeLog NEWS README.md THANKS )
+
+S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
+
+# Maintainer notes:
+# * The build system will always configure & build argp-standalone but it'll never use it
+#   if the argp.h header is found in the system. Which should be the case with
+#   glibc or if argp-standalone is installed.
+
+pkg_setup() {
+	python_setup "python3*"
+	python-single-r1_pkg_setup
+	
+	# Needed for statedumps
+	# https://github.com/gluster/glusterfs/commit/0e50c4b3ea734456c14e2d7a578463999bd332c3
+	enewgroup gluster
+	enewuser gluster -1 -1 "${EPREFIX}"/var/run/gluster gluster
+}
+
+src_prepare() {
+	default
+
+	# build rpc-transport and xlators only once as shared libs
+	find rpc/rpc-transport xlators -name Makefile.am -exec \
+		sed -i 's|.*$(top_srcdir).*\.sym|\0 -shared|' {} + || die
+
+	# fix execution permissions
+	chmod +x libglusterfs/src/gen-defaults.py || die
+
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		YACC=yacc.bison \
+		LEX=flex \
+		--disable-fusermount \
+		--disable-lto \
+		$(use_enable debug) \
+		$(use_enable fuse fuse-client) \
+		$(use_enable georeplication) \
+		$(use_enable static-libs static) \
+		$(use_enable test cmocka) \
+		$(use_enable uring linux-io-uring) \
+		$(use_enable xml xml-output) \
+		$(usex ipv6 --with-ipv6-default "") \
+		$(usex tcmalloc "" --without-tcmalloc) \
+		--with-tmpfilesdir="${EPREFIX}"/usr/lib/tmpfiles.d \
+		--localstatedir="${EPREFIX}"/var
+}
+
+src_compile() {
+	default
+	use emacs && elisp-compile extras/glusterfs-mode.el
+}
+
+src_test() {
+	./run-tests.sh || die
+}
+
+src_install() {
+	default
+
+	# Path changes based on whether app-shells/bash-completion is installed, bug #911523
+	rm -rf "${ED}"/etc/bash_completion.d "${D}$(get_bashcompdir)" || die
+	newbashcomp extras/command-completion/gluster.bash gluster
+
+	rm \
+		"${ED}"/etc/glusterfs/glusterfs-{georep-,}logrotate \
+		"${ED}"/etc/glusterfs/gluster-rsyslog-*.conf \
+		"${ED}"/usr/share/doc/${PF}/glusterfs{-mode.el,.vim} || die "removing false files failed"
+
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}"/glusterfs.logrotate glusterfs
+
+	if use rsyslog ; then
+		insinto /etc/rsyslog.d
+		newins extras/gluster-rsyslog-7.2.conf 60-gluster.conf
+	fi
+
+	if use emacs ; then
+		elisp-install ${PN} extras/glusterfs-mode.el*
+		elisp-site-file-install "${FILESDIR}/50glusterfs-mode-gentoo.el"
+	fi
+
+	insinto /usr/share/vim/vimfiles/ftdetect; doins "${FILESDIR}"/${PN}.vim
+	insinto /usr/share/vim/vimfiles/syntax; doins extras/${PN}.vim
+
+	# insert some other tools which might be useful
+	insinto /usr/share/glusterfs/scripts
+	doins \
+		extras/backend-{cleanup,xattr-sanitize}.sh \
+		extras/clear_xattrs.sh \
+		extras/migrate-unify-to-distribute.sh
+
+	# correct permissions on installed scripts
+	# fperms 0755 /usr/share/glusterfs/scripts/*.sh
+	chmod 0755 "${ED}"/usr/share/glusterfs/scripts/*.sh || die
+
+	newinitd "${FILESDIR}/glusterfsd-10.2.initd" glusterfsd
+	newinitd "${FILESDIR}/glusterd-10.2-r2.initd" glusterd
+	newconfd "${FILESDIR}/${PN}.confd" glusterfsd
+
+	keepdir /var/log/${PN}
+	keepdir /var/lib/glusterd/{events,glusterfind/.keys}
+
+	# QA
+	rm -r "${ED}/var/run/" || die
+	if ! use static-libs; then
+		find "${D}" -type f -name '*.la' -delete || die
+	fi
+
+	python_fix_shebang "${ED}"
+	python_optimize
+}
+
+src_test() {
+	./run-tests.sh || die
+}
+
+pkg_postinst() {
+	tmpfiles_process gluster.conf
+
+	elog "Starting with ${PN}-3.1.0, you can use the glusterd daemon to configure your"
+	elog "volumes dynamically. To do so, simply use the gluster CLI after running:"
+	elog "  /etc/init.d/glusterd start"
+	echo
+	elog "For static configurations, the glusterfsd startup script can be multiplexed."
+	elog "The default startup script uses /etc/conf.d/glusterfsd to configure the"
+	elog "separate service.  To create additional instances of the glusterfsd service"
+	elog "simply create a symlink to the glusterfsd startup script."
+	echo
+	elog "Example:"
+	elog "    # ln -s glusterfsd /etc/init.d/glusterfsd2"
+	elog "    # ${EDITOR} /etc/glusterfs/glusterfsd2.vol"
+	elog "You can now treat glusterfsd2 like any other service"
+	echo
+	ewarn "You need to use a ntp client to keep the clocks synchronized across all"
+	ewarn "of your servers. Setup a NTP synchronizing service before attempting to"
+	ewarn "run GlusterFS."
+	echo
+	elog "If you are upgrading from a previous version of ${PN}, please read:"
+	elog "  http://docs.gluster.org/en/latest/Upgrade-Guide/upgrade_to_$(ver_cut '1-2')/"
+
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}
+
+# vim: noet ts=4 syn=ebuild

--- a/core-server-kit/merge.kit.d/net-base.yml
+++ b/core-server-kit/merge.kit.d/net-base.yml
@@ -43,5 +43,4 @@ target:
     - pkg: www-servers/tornado
 
     - pkg: sys-cluster/singularity
-    - pkg: sys-cluster/glusterfs
     - pkg: sys-cluster/kubectl

--- a/core-server-kit/merge.kit.d/net-base_autogen.yml
+++ b/core-server-kit/merge.kit.d/net-base_autogen.yml
@@ -9,11 +9,9 @@ target:
   url: "https://github.com/macaroni-os/core-server-kit"
   branch: mark-unstable
 
-  fixups:
-    include:
-
   atoms_defaults:
     max_versions: 3
 
   atoms:
     - pkg: net-libs/nghttp2
+    - pkg: sys-cluster/glusterfs


### PR DESCRIPTION
* Create MARK autogen for sys-cluster/glusterfs (needs mark-devkit v0.15.0)
* cleanup openssl dependency removing [-bindist]

See macaroni-os/mark-issues#284