### PR TITLE
[net-kit] net-dns/bind, net-dns/bind-tools - autogen + opensslv3 fix

### DIFF
--- a/net-kit/autogen.kit.d/base.yml
+++ b/net-kit/autogen.kit.d/base.yml
@@ -53,6 +53,29 @@ net_dns_dirlisting:
             match: '.tar.gz'
             replace: ''
 
+
+bind_dirlisting:
+  generator: builtin-dirlisting
+
+  defaults:
+    files_dir: "{{ .Values.pn }}"
+    category: net-dns
+    vars:
+      python_compat: python3+
+      tar_prefix: "bind"
+    dir:
+      url: https://downloads.isc.org/isc/bind9/
+      matcher: '9.*'
+      exclude: 'rc|W|P|ESV|a|b'
+    assets:
+      - name: "{{ .Values.tar_prefix }}-{{ .Values.version }}.tar.xz"
+        prefix: "{{ .Values.version }}/"
+
+  packages:
+    - bind:
+    - bind-tools:
+
+
 net_wireless_noop:
   generator: builtin-noop
   template:

--- a/net-kit/autogen.kit.d/bind/10bind.env
+++ b/net-kit/autogen.kit.d/bind/10bind.env
@@ -1,0 +1,1 @@
+CONFIG_PROTECT="/var/bind"

--- a/net-kit/autogen.kit.d/bind/generate-rndc-key.sh
+++ b/net-kit/autogen.kit.d/bind/generate-rndc-key.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ ! -s /etc/bind/rndc.key ]; then
+    /usr/sbin/rndc-confgen -a > /dev/null 2>&1 || exit 1
+    chmod 640 /etc/bind/rndc.key
+    chown root.named /etc/bind/rndc.key
+fi

--- a/net-kit/autogen.kit.d/bind/localhost.zone-r3
+++ b/net-kit/autogen.kit.d/bind/localhost.zone-r3
@@ -1,0 +1,11 @@
+$TTL 1W
+@       IN      SOA     localhost. root.localhost.  (
+                                      2008122601 ; Serial
+                                      28800      ; Refresh
+                                      14400      ; Retry
+                                      604800     ; Expire - 1 week
+                                      86400 )    ; Minimum
+@		IN      NS      localhost.
+@		IN	A	127.0.0.1
+
+@		IN	AAAA	::1

--- a/net-kit/autogen.kit.d/bind/named.cache-r3
+++ b/net-kit/autogen.kit.d/bind/named.cache-r3
@@ -1,0 +1,92 @@
+;       This file holds the information on root name servers needed to 
+;       initialize cache of Internet domain name servers
+;       (e.g. reference this file in the "cache  .  <file>"
+;       configuration file of BIND domain name servers). 
+; 
+;       This file is made available by InterNIC 
+;       under anonymous FTP as
+;           file                /domain/named.cache 
+;           on server           FTP.INTERNIC.NET
+;       -OR-                    RS.INTERNIC.NET
+; 
+;       last update:     November 16, 2017 
+;       related version of root zone:     2017111601
+; 
+; FORMERLY NS.INTERNIC.NET 
+;
+.                        3600000      NS    A.ROOT-SERVERS.NET.
+A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
+A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
+; 
+; FORMERLY NS1.ISI.EDU 
+;
+.                        3600000      NS    B.ROOT-SERVERS.NET.
+B.ROOT-SERVERS.NET.      3600000      A     199.9.14.201
+B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:200::b
+; 
+; FORMERLY C.PSI.NET 
+;
+.                        3600000      NS    C.ROOT-SERVERS.NET.
+C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
+C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
+; 
+; FORMERLY TERP.UMD.EDU 
+;
+.                        3600000      NS    D.ROOT-SERVERS.NET.
+D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
+D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
+; 
+; FORMERLY NS.NASA.GOV
+;
+.                        3600000      NS    E.ROOT-SERVERS.NET.
+E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
+E.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:a8::e
+; 
+; FORMERLY NS.ISC.ORG
+;
+.                        3600000      NS    F.ROOT-SERVERS.NET.
+F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
+F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
+; 
+; FORMERLY NS.NIC.DDN.MIL
+;
+.                        3600000      NS    G.ROOT-SERVERS.NET.
+G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
+G.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:12::d0d
+; 
+; FORMERLY AOS.ARL.ARMY.MIL
+;
+.                        3600000      NS    H.ROOT-SERVERS.NET.
+H.ROOT-SERVERS.NET.      3600000      A     198.97.190.53
+H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::53
+; 
+; FORMERLY NIC.NORDU.NET
+;
+.                        3600000      NS    I.ROOT-SERVERS.NET.
+I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
+I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
+; 
+; OPERATED BY VERISIGN, INC.
+;
+.                        3600000      NS    J.ROOT-SERVERS.NET.
+J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
+J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
+; 
+; OPERATED BY RIPE NCC
+;
+.                        3600000      NS    K.ROOT-SERVERS.NET.
+K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
+K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
+; 
+; OPERATED BY ICANN
+;
+.                        3600000      NS    L.ROOT-SERVERS.NET.
+L.ROOT-SERVERS.NET.      3600000      A     199.7.83.42
+L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:9f::42
+; 
+; OPERATED BY WIDE
+;
+.                        3600000      NS    M.ROOT-SERVERS.NET.
+M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
+M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
+; End of file

--- a/net-kit/autogen.kit.d/bind/named.conf
+++ b/net-kit/autogen.kit.d/bind/named.conf
@@ -1,0 +1,1 @@
+d /run/named 0750 named named -

--- a/net-kit/autogen.kit.d/bind/named.conf-r8
+++ b/net-kit/autogen.kit.d/bind/named.conf-r8
@@ -1,0 +1,165 @@
+/*
+ * Refer to the named.conf(5) and named(8) man pages, and the documentation
+ * in /usr/share/doc/bind-* for more details.
+ * Online versions of the documentation can be found here:
+ * https://kb.isc.org/article/AA-01031
+ *
+ * If you are going to set up an authoritative server, make sure you
+ * understand the hairy details of how DNS works. Even with simple mistakes,
+ * you can break connectivity for affected parties, or cause huge amounts of
+ * useless Internet traffic.
+ */
+
+acl "xfer" {
+	/* Deny transfers by default except for the listed hosts.
+	 * If we have other name servers, place them here.
+	 */
+	none;
+};
+
+/*
+ * You might put in here some ips which are allowed to use the cache or
+ * recursive queries
+ */
+acl "trusted" {
+	127.0.0.0/8;
+	::1/128;
+};
+
+options {
+	directory "/var/bind";
+	pid-file "/run/named/named.pid";
+
+	/* https://www.isc.org/solutions/dlv >=bind-9.7.x only */
+	//bindkeys-file "/etc/bind/bind.keys";
+
+	listen-on-v6 { ::1; };
+	listen-on { 127.0.0.1; };
+
+	allow-query {
+		/*
+		 * Accept queries from our "trusted" ACL.  We will
+		 * allow anyone to query our master zones below.
+		 * This prevents us from becoming a free DNS server
+		 * to the masses.
+		 */
+		trusted;
+	};
+
+	allow-query-cache {
+		/* Use the cache for the "trusted" ACL. */
+		trusted;
+	};
+
+	allow-recursion {
+		/* Only trusted addresses are allowed to use recursion. */
+		trusted;
+	};
+
+	allow-transfer {
+		/* Zone tranfers are denied by default. */
+		none;
+	};
+
+	allow-update {
+		/* Don't allow updates, e.g. via nsupdate. */
+		none;
+	};
+
+	/*
+	* If you've got a DNS server around at your upstream provider, enter its
+	* IP address here, and enable the line below. This will make you benefit
+	* from its cache, thus reduce overall DNS traffic in the Internet.
+	*
+	* Uncomment the following lines to turn on DNS forwarding, and change
+	*  and/or update the forwarding ip address(es):
+	*/
+/*
+	forward first;
+	forwarders {
+	//	123.123.123.123;	// Your ISP NS
+	//	124.124.124.124;	// Your ISP NS
+	//	4.2.2.1;		// Level3 Public DNS
+	//	4.2.2.2;		// Level3 Public DNS
+		8.8.8.8;		// Google Open DNS
+		8.8.4.4;		// Google Open DNS
+	};
+
+*/
+
+	//dnssec-validation yes;
+
+	/*
+	 * As of bind 9.8.0:
+	 * "If the root key provided has expired,
+	 * named will log the expiration and validation will not work."
+	 */
+	dnssec-validation auto;
+
+	/* if you have problems and are behind a firewall: */
+	//query-source address * port 53;
+};
+
+/*
+logging {
+	channel default_log {
+		file "/var/log/named/named.log" versions 5 size 50M;
+		print-time yes;
+		print-severity yes;
+		print-category yes;
+	};
+
+	category default { default_log; };
+	category general { default_log; };
+};
+*/
+
+include "/etc/bind/rndc.key";
+controls {
+	inet 127.0.0.1 port 953 allow { 127.0.0.1/32; ::1/128; } keys { "rndc-key"; };
+};
+
+zone "." in {
+	type hint;
+	file "/var/bind/named.cache";
+};
+
+zone "localhost" IN {
+	type master;
+	file "pri/localhost.zone";
+	notify no;
+};
+
+/*
+ * Briefly, a zone which has been declared delegation-only will be effectively
+ * limited to containing NS RRs for subdomains, but no actual data beyond its
+ * own apex (for example, its SOA RR and apex NS RRset). This can be used to
+ * filter out "wildcard" or "synthesized" data from NAT boxes or from
+ * authoritative name servers whose undelegated (in-zone) data is of no
+ * interest.
+ * See http://www.isc.org/software/bind/delegation-only for more info
+ */
+
+//zone "COM" { type delegation-only; };
+//zone "NET" { type delegation-only; };
+
+//zone "YOUR-DOMAIN.TLD" {
+//	type master;
+//	file "/var/bind/pri/YOUR-DOMAIN.TLD.zone";
+//	allow-query { any; };
+//	allow-transfer { xfer; };
+//};
+
+//zone "YOUR-SLAVE.TLD" {
+//	type slave;
+//	file "/var/bind/sec/YOUR-SLAVE.TLD.zone";
+//	masters { <MASTER>; };
+
+	/* Anybody is allowed to query but transfer should be controlled by the master. */
+//	allow-query { any; };
+//	allow-transfer { none; };
+
+	/* The master should be the only one who notifies the slaves, shouldn't it? */
+//	allow-notify { <MASTER>; };
+//	notify no;
+//};

--- a/net-kit/autogen.kit.d/bind/named.confd-r7
+++ b/net-kit/autogen.kit.d/bind/named.confd-r7
@@ -1,0 +1,48 @@
+# Set various named options here.
+#
+#OPTIONS=""
+
+# Set this to the number of processors you want bind to use.
+# Leave this unchanged if you want bind to automatically detect the number
+#CPU="1"
+
+# If you wish to run bind in a chroot:
+# 1) un-comment the CHROOT= assignment, below. You may use
+#    a different chroot directory but MAKE SURE it's empty.
+# 2) run: emerge --config =<bind-version>
+#
+#CHROOT="/chroot/dns"
+
+# Uncomment to enable binmount of /usr/share/GeoIP
+#CHROOT_GEOIP="1"
+
+# Uncomment the line below to avoid that the init script mounts the needed paths
+# into the chroot directory.
+# You have to copy all needed config files by hand if you say CHROOT_NOMOUNT="1".
+#CHROOT_NOMOUNT="1"
+
+# Uncomment this option if you have setup your own chroot environment and you
+# don't want/need the chroot consistency check
+#CHROOT_NOCHECK=1
+
+# Default pid file location
+PIDFILE="${CHROOT}/run/named/named.pid"
+
+# Scheduling priority: 19 is the lowest and -20 is the highest.
+# Default: 0
+#NAMED_NICELEVEL="0"
+
+# Uncomment rc_named_use/rc_named_after for the database you need.
+# Its necessary to ensure the database backend will be started before named.
+
+# MySQL
+#rc_named_use="mysql"
+#rc_named_after="mysql"
+
+# PostgreSQL
+#rc_named_use="pg_autovacuum postgresql"
+#rc_named_after="pg_autovacuum postgresql"
+
+# LDAP
+#rc_named_use="ldap"
+#rc_named_after="ldap"

--- a/net-kit/autogen.kit.d/bind/named.init-r14
+++ b/net-kit/autogen.kit.d/bind/named.init-r14
@@ -1,0 +1,252 @@
+#!/sbin/openrc-run
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+extra_commands="checkconfig checkzones"
+extra_started_commands="reload"
+
+depend() {
+	need net
+	use logger
+	provide dns
+}
+
+NAMED_CONF=${CHROOT}/etc/bind/named.conf
+
+OPENSSL_LIBGOST=${OPENSSL_LIBGOST:-0}
+MOUNT_CHECK_TIMEOUT=${MOUNT_CHECK_TIMEOUT:-60}
+
+_mount() {
+	local from
+	local to
+	local opts
+	local ret=0
+
+	if [ "${#}" -lt 3 ]; then
+		eerror "_mount(): to few arguments"
+		return 1
+	fi
+
+	from=$1
+	to=$2
+	shift 2
+
+	opts="${*}"
+	shift $#
+
+	if [ -z "$(awk "\$2 == \"${to}\" { print \$2 }" /proc/mounts)" ]; then
+		einfo "mounting ${from} to ${to}"
+		mount ${from} ${to} ${opts}
+		ret=$?
+
+		eend $ret
+		return $ret
+	fi
+
+	return 0
+}
+
+_umount() {
+	local dir=$1
+	local ret=0
+
+	if [ -n "$(awk "\$2 == \"${dir}\" { print \$2 }" /proc/mounts)" ]; then
+		ebegin "umounting ${dir}"
+		umount ${dir}
+		ret=$?
+
+		eend $ret
+		return $ret
+	fi
+
+	return 0
+}
+
+_get_pidfile() {
+	# as suggested in bug #107724, bug 335398#c17
+	[ -n "${PIDFILE}" ] || PIDFILE=${CHROOT}$(\
+			/usr/bin/named-checkconf -p ${CHROOT:+-t} ${CHROOT} ${NAMED_CONF#${CHROOT}} | grep 'pid-file' | cut -d\" -f2)
+	[ -z "${PIDFILE}" ] && PIDFILE=${CHROOT}/run/named/named.pid
+}
+
+check_chroot() {
+	if [ -n "${CHROOT}" ]; then
+		[ ! -d "${CHROOT}" ] && return 1
+		[ ! -d "${CHROOT}/dev" ] || [ ! -d "${CHROOT}/etc" ] || [ ! -d "${CHROOT}/var" ] && return 1
+		[ ! -d "${CHROOT}/run" ] || [ ! -d "${CHROOT}/var/log" ] && return 1
+		[ ! -d "${CHROOT}/etc/bind" ] || [ ! -d "${CHROOT}/var/bind" ] && return 1
+		[ ! -d "${CHROOT}/var/log/named" ] && return 1
+		[ ! -c "${CHROOT}/dev/null" ] || [ ! -c "${CHROOT}/dev/zero" ] && return 1
+		[ ! -c "${CHROOT}/dev/urandom" ] && return 1
+		[ "${CHROOT_GEOIP:-0}" -eq 1 ] && [ ! -d "${CHROOT}/usr/share/GeoIP" ] && return 1
+		if [ ${OPENSSL_LIBGOST:-0} -eq 1 ]; then
+			if [ -d "/usr/lib64" ]; then
+				[ ! -d "${CHROOT}/usr/lib64/engines" ] && return 1
+			elif [ -d "/usr/lib" ]; then
+				[ ! -d "${CHROOT}/usr/lib/engines" ] && return 1
+			fi
+		fi
+	fi
+
+	return 0
+}
+
+checkconfig() {
+	ebegin "Checking named configuration"
+
+	if [ ! -f "${NAMED_CONF}" ] ; then
+		eerror "No ${NAMED_CONF} file exists!"
+		return 1
+	fi
+
+	/usr/bin/named-checkconf ${CHROOT:+-t} ${CHROOT} ${NAMED_CONF#${CHROOT}} || {
+		eerror "named-checkconf failed! Please fix your config first."
+		return 1
+	}
+
+	eend 0
+	return 0
+}
+
+checkzones() {
+	ebegin "Checking named configuration and zones"
+	/usr/bin/named-checkconf -z -j ${CHROOT:+-t} ${CHROOT} ${NAMED_CONF#${CHROOT}}
+	eend $?
+}
+
+start() {
+	local piddir
+
+	ebegin "Starting ${CHROOT:+chrooted }named"
+
+	if [ -n "${CHROOT}" ]; then
+		if [ ${CHROOT_NOCHECK:-0} -eq 0 ]; then
+			check_chroot || {
+				eend 1
+				eerror "Your chroot dir ${CHROOT} is inconsistent, please run 'emerge --config net-dns/bind' first"
+				return 1
+			}
+		fi
+
+		if [ ${OPENSSL_LIBGOST:-0} -eq 1 ]; then
+			if [ ! -e /usr/lib/engines/libgost.so ]; then
+				eend 1
+				eerror "Couldn't find /usr/lib/engines/libgost.so but bind has been built with openssl and libgost support"
+				return 1
+			fi
+			cp -Lp /usr/lib/engines/libgost.so "${CHROOT}/usr/lib/engines/libgost.so" || {
+				eend 1
+				eerror "Couldn't copy /usr/lib/engines/libgost.so into '${CHROOT}/usr/lib/engines/'"
+				return 1
+			}
+		fi
+		cp -Lp /etc/localtime "${CHROOT}/etc/localtime"
+
+		if [ "${CHROOT_NOMOUNT:-0}" -eq 0 ]; then
+			einfo "Mounting chroot dirs"
+			_mount /etc/bind ${CHROOT}/etc/bind -o bind
+			_mount /var/bind ${CHROOT}/var/bind -o bind
+			_mount /var/log/named ${CHROOT}/var/log/named -o bind
+			if [ "${CHROOT_GEOIP:-0}" -eq 1 ]; then
+				_mount /usr/share/GeoIP ${CHROOT}/usr/share/GeoIP -o bind
+			fi
+		fi
+
+		# On initial startup, if piddir inside the chroot /var/run/named
+		# Then the .../var/run part might not exist yet
+		checkpath -q -d -o root:root -m 0755 "${piddir}/.."
+	fi
+
+	checkconfig || { eend 1; return 1; }
+
+	# create piddir (usually /run/named) if necessary, bug 334535
+	_get_pidfile
+	piddir="${PIDFILE%/*}"
+	checkpath -q -d -o root:named -m 0770 "${piddir}" || {
+		eerror "Failed to create PID directory at $piddir"
+		eend 1
+		return 1
+	}
+
+	# In case someone have $CPU set in /etc/conf.d/named
+	if [ -n "${CPU}" ] && [ "${CPU}" -gt 0 ]; then
+		CPU="-n ${CPU}"
+	fi
+
+	start-stop-daemon --start --pidfile ${PIDFILE} \
+		--nicelevel ${NAMED_NICELEVEL:-0} \
+		--exec /usr/sbin/named \
+		-- -u named ${CPU} ${OPTIONS} ${CHROOT:+-t} ${CHROOT}
+	eend $?
+}
+
+stop() {
+	local reported=0
+
+	ebegin "Stopping ${CHROOT:+chrooted }named"
+
+	# Workaround for now, until openrc's restart has been fixed.
+	# openrc doesn't care about a restart() function in init scripts.
+	if [ "${RC_CMD}" = "restart" ]; then
+		if [ -n "${CHROOT}" -a ${CHROOT_NOCHECK:-0} -eq 0 ]; then
+			check_chroot || {
+				eend 1
+				eerror "Your chroot dir ${CHROOT} is inconsistent, please run 'emerge --config net-dns/bind' first"
+				return 1
+			}
+		fi
+
+		checkconfig || { eend 1; return 1; }
+	fi
+
+	# -R 10, bug 335398
+	_get_pidfile
+	start-stop-daemon --stop --retry 10 --pidfile $PIDFILE \
+		--exec /usr/sbin/named
+
+	if [ -n "${CHROOT}" ] && [ "${CHROOT_NOMOUNT:-0}" -eq 0 ]; then
+		ebegin "Umounting chroot dirs"
+
+		# just to be sure everything gets clean
+		while fuser -s ${CHROOT} 2>/dev/null; do
+			if [ "${reported}" -eq 0 ]; then
+				einfo "Waiting until all named processes are stopped (max. ${MOUNT_CHECK_TIMEOUT} seconds)"
+			elif [ "${reported}" -eq "${MOUNT_CHECK_TIMEOUT}" ]; then
+				eerror "Waiting until all named processes are stopped failed!"
+				eend 1
+				break
+			fi
+			sleep 1
+			reported=$((reported+1))
+		done
+
+		[ "${CHROOT_GEOIP:-0}" -eq 1 ] && _umount ${CHROOT}/usr/share/GeoIP
+		_umount ${CHROOT}/etc/bind
+		_umount ${CHROOT}/var/log/named
+		_umount ${CHROOT}/var/bind
+	fi
+
+	eend $?
+}
+
+reload() {
+	local ret
+
+	ebegin "Reloading named.conf and zone files"
+
+	checkconfig || { eend 1; return 1; }
+
+	_get_pidfile
+	if [ -n "${PIDFILE}" ]; then
+		start-stop-daemon --pidfile $PIDFILE --signal HUP
+		ret=$?
+	else
+		ewarn "Unable to determine the pidfile... this is"
+		ewarn "a fallback mode. Please check your installation!"
+
+		$RC_SERVICE restart
+		ret=$?
+	fi
+
+	eend $ret
+}

--- a/net-kit/autogen.kit.d/templates/bind-tools.tmpl
+++ b/net-kit/autogen.kit.d/templates/bind-tools.tmpl
@@ -1,0 +1,106 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools flag-o-matic toolchain-funcs
+
+DESCRIPTION="bind tools: dig, nslookup, host, nsupdate, dnssec-keygen"
+HOMEPAGE="https://www.isc.org/software/bind"
+SRC_URI="{{.Values.src_uri}}"
+
+LICENSE="Apache-2.0 BSD BSD-2 GPL-2 HPND ISC MPL-2.0"
+SLOT="0"
+KEYWORDS="*"
+IUSE="doc gssapi idn ipv6 libedit readline xml"
+# no PKCS11 currently as it requires OpenSSL to be patched, also see bug 409687
+
+COMMON_DEPEND="
+	dev-libs/libuv:=
+	dev-libs/openssl
+	dev-libs/userspace-rcu
+	sys-libs/libcap
+	xml? ( dev-libs/libxml2 )
+	idn? ( net-dns/libidn2:= )
+	gssapi? ( virtual/krb5 )
+	libedit? ( dev-libs/libedit )
+	!libedit? (
+		readline? ( sys-libs/readline:= )
+	)
+"
+DEPEND="${COMMON_DEPEND}"
+RDEPEND="${COMMON_DEPEND}
+	!<=net-dns/bind-9.18.1-r2
+"
+
+# sphinx required for man-page and html creation
+BDEPEND="
+	doc? ( dev-python/sphinx )
+	virtual/pkgconfig
+"
+
+# bug 479092, requires networking
+RESTRICT="test"
+
+src_prepare() {
+	default
+
+	export LDFLAGS="${LDFLAGS} -L${EPREFIX}/usr/$(get_libdir)"
+
+	# Disable tests for now, bug 406399
+	sed -i '/^SUBDIRS/s:tests::' bin/Makefile.in lib/Makefile.in || die
+
+	# bug #220361
+	rm aclocal.m4 || die
+	rm -rf libtool.m4/ || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--localstatedir="${EPREFIX}"/var
+		--without-json-c
+		--without-zlib
+		--without-lmdb
+		--without-maxminddb
+		--disable-geoip
+		--with-openssl="${ESYSROOT}"/usr
+		$(use_with idn libidn2 "${ESYSROOT}"/usr)
+		$(use_with xml libxml2)
+		$(use_with gssapi)
+		AR="$(type -P $(tc-getAR))"
+	)
+
+	# bug 607400
+	if use libedit ; then
+		myeconfargs+=( --with-readline=libedit )
+	elif use readline ; then
+		myeconfargs+=( --with-readline=readline )
+	else
+		myeconfargs+=( --without-readline )
+	fi
+
+	# bug 344029
+	append-cflags "-DDIG_SIGCHASE"
+
+	# to expose CMSG_* macros from sys/sockets.h
+	[[ ${CHOST} == *-solaris* ]] && append-cflags "-D_XOPEN_SOURCE=600"
+
+	# localstatedir for nsupdate -l, bug 395785
+	tc-export BUILD_CC
+	econf "${myeconfargs[@]}"
+
+	# bug #151839
+	echo '#undef SO_BSDCOMPAT' >> config.h
+}
+
+src_install() {
+	default
+
+	rm -r "${D}"/usr/bin/{arpaname,named*,nsec3hash} || die
+	rm -r "${D}"/usr/{include,sbin} || die
+	rm -r "${D}"/usr/share/man/man*/{arpaname,named,nsec3hash}* || die
+	rm -r "${D}"/usr/share/man/man{5,8} || die
+}
+
+# vim: filetype=ebuild

--- a/net-kit/autogen.kit.d/templates/bind.tmpl
+++ b/net-kit/autogen.kit.d/templates/bind.tmpl
@@ -1,0 +1,273 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( {{.Values.python_compat}} )
+
+inherit python-any-r1 autotools toolchain-funcs flag-o-matic tmpfiles user
+
+DESCRIPTION="Berkeley Internet Name Domain - Name Server"
+HOMEPAGE="https://www.isc.org/software/bind"
+SRC_URI="{{.Values.src_uri}}"
+
+LICENSE="Apache-2.0 BSD BSD-2 GPL-2 HPND ISC MPL-2.0"
+SLOT="0"
+KEYWORDS="*"
+IUSE="dnstap dnsrps doc doh fixed-rrset geoip gssapi idn lmdb selinux test urandom xml"
+
+DEPEND="
+	=net-dns/bind-tools-${PV}*
+	dev-libs/jemalloc
+	dev-libs/json-c:=
+	dev-libs/libuv:=
+	dev-libs/openssl
+	sys-libs/libcap
+	sys-libs/zlib
+	doh? ( net-libs/nghttp2 )
+	geoip? ( dev-libs/libmaxminddb )
+	gssapi? ( virtual/krb5 )
+	idn? ( net-dns/libidn2 )
+	lmdb? ( dev-db/lmdb )
+	dnstap? ( dev-libs/fstrm dev-libs/protobuf-c )
+	xml? ( dev-libs/libxml2 )
+"
+BDEPEND="
+	test? (
+		${PYTHON_DEPS}
+		dev-python/dnspython
+		dev-python/pytest
+		dev-perl/Net-DNS-SEC
+		dev-util/cmocka
+	)
+"
+
+RDEPEND="${DEPEND}
+	selinux? ( sec-policy/selinux-bind )
+	sys-process/psmisc"
+
+pkg_setup() {
+	ebegin "Creating named group and user"
+	enewgroup named 40
+	enewuser named 40 -1 /etc/bind named
+	eend ${?}
+}
+
+src_prepare() {
+	default
+
+	# should be installed by bind-tools
+	sed -i -r -e "s:(nsupdate|dig|delv) ::g" bin/Makefile.in || die
+
+	# Disable tests for now, bug 406399
+	#sed -i '/^SUBDIRS/s:tests::' bin/Makefile.in lib/Makefile.in || die
+
+	# bug #220361
+	rm aclocal.m4 || die
+	rm -rf libtool.m4/ || die
+	eautoreconf
+
+}
+
+src_configure() {
+	local myeconfargs=(
+		AR="$(type -P $(tc-getAR))"
+		--prefix="${EPREFIX}"/usr
+		--sysconfdir="${EPREFIX}"/etc/bind
+		--localstatedir="${EPREFIX}"/var
+		--enable-full-report
+		--without-readline
+		--with-openssl="${ESYSROOT}"/usr
+		--with-jemalloc
+		--with-json-c
+		--with-zlib
+		$(use_enable dnstap)
+		$(use_enable dnsrps)
+		$(use_enable dnsrps dnsrps-dl)
+		$(use_enable doh)
+		$(use_enable fixed-rrset)
+		$(use_enable geoip )
+		$(use_with doh libnghttp2)
+		$(use_with geoip maxminddb)
+		$(use_with gssapi)
+		$(use_with lmdb)
+		$(use_with xml libxml2)
+		"${@}"
+	)
+
+	export BUILD_CC=$(tc-getBUILD_CC)
+	econf "${myeconfargs[@]}"
+
+	# bug #151839
+	echo '#undef SO_BSDCOMPAT' >> config.h
+}
+
+src_install() {
+	default
+
+	dodoc README.md
+
+	if use doc; then
+		docinto misc
+		dodoc -r doc/misc/
+
+		# might a 'html' useflag make sense?
+		docinto html
+		dodoc -r doc/arm/
+
+		docinto contrib
+		dodoc contrib/scripts/nanny.pl
+	fi
+
+	insinto /etc/bind
+	newins "${FILESDIR}"/named.conf-r8 named.conf
+
+	# ftp://ftp.rs.internic.net/domain/named.cache:
+	insinto /var/bind
+	newins "${FILESDIR}"/named.cache-r3 named.cache
+
+	insinto /var/bind/pri
+	newins "${FILESDIR}"/localhost.zone-r3 localhost.zone
+
+	newinitd "${FILESDIR}"/named.init-r14 named
+	newconfd "${FILESDIR}"/named.confd-r7 named
+
+	newenvd "${FILESDIR}"/10bind.env 10bind
+
+	# Let's get rid of those tools and their manpages since they're provided by bind-tools
+	rm -f "${ED}"/usr/share/man/man1/{dig,dnssec-ksr,host,mdig,nslookup,delv,nsupdate}.1* || die
+	rm -f "${ED}"/usr/share/man/man8/nsupdate.8* || die
+	rm -f "${ED}"/usr/bin/{dig,delv,dnssec-ksr,host,mdig,nslookup,nsupdate} || die
+	rm -f "${ED}"/usr/sbin/{dig,delv,host,mdig,nslookup,nsupdate} || die
+	rm -r "${ED}"/usr/lib* || die
+	for tool in cds dsfromkey importkey keyfromlabel keygen \
+	revoke settime signzone verify; do
+		rm -f "${ED}"/usr/{,s}bin/dnssec-"${tool}" || die
+		rm -f "${ED}"/usr/share/man/man1/dnssec-"${tool}".1* || die
+	done
+
+	# bug 405251
+	find "${ED}" -type f -name '*.a' -delete || die
+	find "${ED}" -type f -name '*.la' -delete || die
+
+	# bug 450406
+	dosym named.cache /var/bind/root.cache
+
+	dosym ../../var/bind/pri /etc/bind/pri
+	dosym ../../var/bind/sec /etc/bind/sec
+	dosym ../../var/bind/dyn /etc/bind/dyn
+	keepdir /var/bind/{pri,sec,dyn} /var/log/named
+
+	fowners root:named /{etc,var}/bind /var/log/named /var/bind/{sec,pri,dyn}
+	fowners root:named /var/bind/named.cache /var/bind/pri/localhost.zone /etc/bind/named.conf
+	fperms 0640 /var/bind/named.cache /var/bind/pri/localhost.zone /etc/bind/named.conf
+	fperms 0750 /etc/bind /var/bind/pri
+	fperms 0770 /var/log/named /var/bind/{,sec,dyn}
+
+	dotmpfiles "${FILESDIR}"/named.conf
+	exeinto /usr/libexec
+	doexe "${FILESDIR}/generate-rndc-key.sh"
+}
+
+pkg_postinst() {
+	tmpfiles_process named.conf
+
+	if [[ ! -f '/etc/bind/rndc.key' && ! -f '/etc/bind/rndc.conf' ]]; then
+		if use urandom ; then
+			einfo "Using /dev/urandom for generating rndc.key"
+			usr/sbin/rndc-confgen -r /dev/urandom -a
+			echo
+		else
+			einfo "Using /dev/random for generating rndc.key"
+			/usr/sbin/rndc-confgen -a
+			echo
+		fi
+		chown root:named /etc/bind/rndc.key || die
+		chmod 0640 /etc/bind/rndc.key || die
+	fi
+
+	einfo
+	einfo "You can edit /etc/conf.d/named to customize named settings"
+	einfo
+	einfo "If you'd like to run bind in a chroot AND this is a new"
+	einfo "install OR your bind doesn't already run in a chroot:"
+	einfo "1) Uncomment and set the CHROOT variable in /etc/conf.d/named."
+	einfo "2) Run \`emerge --config '=${CATEGORY}/${PF}'\`"
+	einfo
+
+	CHROOT=$(source /etc/conf.d/named 2>/dev/null; echo ${CHROOT})
+	if [[ -n ${CHROOT} ]]; then
+		elog "NOTE: As of net-dns/bind-9.4.3_p5-r1 the chroot part of the init-script got some major changes!"
+		elog "To enable the old behaviour (without using mount) uncomment the"
+		elog "CHROOT_NOMOUNT option in your /etc/conf.d/named config."
+		elog "If you decide to use the new/default method, ensure to make backup"
+		elog "first and merge your existing configs/zones to /etc/bind and"
+		elog "/var/bind because bind will now mount the needed directories into"
+		elog "the chroot dir."
+	fi
+}
+
+pkg_config() {
+	CHROOT=$(source /etc/conf.d/named; echo ${CHROOT})
+	CHROOT_NOMOUNT=$(source /etc/conf.d/named; echo ${CHROOT_NOMOUNT})
+	CHROOT_GEOIP=$(source /etc/conf.d/named; echo ${CHROOT_GEOIP})
+
+	if [[ -z "${CHROOT}" ]]; then
+		eerror "This config script is designed to automate setting up"
+		eerror "a chrooted bind/named. To do so, please first uncomment"
+		eerror "and set the CHROOT variable in '/etc/conf.d/named'."
+		die "Unset CHROOT"
+	fi
+	if [[ -d "${CHROOT}" ]]; then
+		ewarn "NOTE: As of net-dns/bind-9.4.3_p5-r1 the chroot part of the init-script got some major changes!"
+		ewarn "To enable the old behaviour (without using mount) uncomment the"
+		ewarn "CHROOT_NOMOUNT option in your /etc/conf.d/named config."
+		ewarn
+		ewarn "${CHROOT} already exists... some things might become overridden"
+		ewarn "press CTRL+C if you don't want to continue"
+		sleep 10
+	fi
+
+	echo; einfo "Setting up the chroot directory..."
+
+	mkdir -m 0750 -p ${CHROOT} || die
+	mkdir -m 0755 -p ${CHROOT}/{dev,etc,var/log,run} || die
+	mkdir -m 0750 -p ${CHROOT}/etc/bind || die
+	mkdir -m 0770 -p ${CHROOT}/var/{bind,log/named} ${CHROOT}/run/named/ || die
+
+	chown root:named \
+		${CHROOT} \
+		${CHROOT}/var/{bind,log/named} \
+		${CHROOT}/run/named/ \
+		${CHROOT}/etc/bind \
+		|| die
+
+	mknod ${CHROOT}/dev/null c 1 3 || die
+	chmod 0666 ${CHROOT}/dev/null || die
+
+	mknod ${CHROOT}/dev/zero c 1 5 || die
+	chmod 0666 ${CHROOT}/dev/zero || die
+
+	if use urandom; then
+		mknod ${CHROOT}/dev/urandom c 1 9 || die
+		chmod 0666 ${CHROOT}/dev/urandom || die
+	else
+		mknod ${CHROOT}/dev/random c 1 8 || die
+		chmod 0666 ${CHROOT}/dev/random || die
+	fi
+
+	if [ "${CHROOT_NOMOUNT:-0}" -ne 0 ]; then
+		cp -a /etc/bind ${CHROOT}/etc/ || die
+		cp -a /var/bind ${CHROOT}/var/ || die
+	fi
+
+	if [ "${CHROOT_GEOIP:-0}" -eq 1 ]; then
+		if use geoip; then
+			mkdir -m 0755 -p ${CHROOT}/usr/share/GeoIP || die
+		fi
+	fi
+
+	elog "You may need to add the following line to your syslog-ng.conf:"
+	elog "source jail { unix-stream(\"${CHROOT}/dev/log\"); };"
+}
+
+# vim: filetype=ebuild

--- a/net-kit/merge.kit.d/base.yml
+++ b/net-kit/merge.kit.d/base.yml
@@ -59,8 +59,6 @@ target:
     - pkg: net-dialup/minicom
 
     - pkg: net-dns/avahi
-    - pkg: net-dns/bind
-    - pkg: net-dns/bind-tools
     - pkg: net-dns/coredns
     - pkg: net-dns/dnsmasq
     - pkg: net-dns/dnssec-root

--- a/net-kit/merge.kit.d/base_autogen.yml
+++ b/net-kit/merge.kit.d/base_autogen.yml
@@ -13,6 +13,8 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: net-dns/bind
+    - pkg: net-dns/bind-tools
     - pkg: net-dns/unbound
 
     - pkg: net-vpn/strongswan


### PR DESCRIPTION
* autogen files with builtin-dirlisting
* remove reference to dev-libs/openssl[-bindist]

Closes: macaroni-os/mark-issues#285