### PR TITLE
[python-modules-kit] dev-python/pymongo - Add select

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -1836,6 +1836,7 @@ dev_python_simplified_rule:
         revision:
           4.0: 1
           4.8.0: 1
+        select: '4.*'
         blocker: "!<dev-python/pymongo-4.0" #block all older versions
         iuse: kerberos
         pydeps:


### PR DESCRIPTION
In order to skip version 10.10.10.10 we force
version 4.x for now.

Closes: macaroni-os/mark-issues#293