### PR TITLE
[core-server-kit] dev-db/sqlite  Remove intermediate version pinning

### DIFF
--- a/core-server-kit/curated/dev-db/sqlite/autogen.yaml
+++ b/core-server-kit/curated/dev-db/sqlite/autogen.yaml
@@ -2,7 +2,6 @@ sqlite:
   generator: github-1
   packages:
     - sqlite:
-        version: 3.47.2
         github:
           query: tags
           transform:

--- a/core-server-kit/curated/dev-db/sqlite/templates/sqlite.tmpl
+++ b/core-server-kit/curated/dev-db/sqlite/templates/sqlite.tmpl
@@ -29,11 +29,6 @@ DEPEND="${RDEPEND}
 
 S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
 
-src_prepare() {
-	eapply_user
-	eautoreconf
-}
-
 src_configure() {
 	local -x CPPFLAGS="${CPPFLAGS}" CFLAGS="${CFLAGS}"
 	local options=()
@@ -171,7 +166,15 @@ src_configure() {
 		# Support ICU extension.
 		# https://sqlite.org/compile.html#enable_icu
 		append-cppflags -DSQLITE_ENABLE_ICU
-		sed -e "s/^TLIBS = @LIBS@/& -licui18n -licuuc/" -i Makefile.in || die "sed failed"
+
+		# sqlite needs a little help properly linking to ICU. Its automatic configure code
+		# doesn't seem to work, so we will use pkg-config directly to extract all libraries
+		# to link against: (See ext/icu/README.txt and auto.def for more details)
+
+		for lib in i18n io uc; do
+			pkg-config icu-$lib --libs >> $T/icu_ld.txt || die
+		done
+		options+=( --with-icu-ldflags="$(cat $T/icu_ld.txt | tr '\n' ' ' )" )
 	fi
 
 	# readline USE flag.


### PR DESCRIPTION
Summary
========
* Removed intermediate version pinning
* Removed the src_prepare function adjusted the ICU linking process to use pkg-config for improved accuracy. This ensures better compatibility with ICU libraries based on SQLite's documentation and build requirements. 
* Inspired by 9df86e0d5a6e5a684ef0de2cc5f4c2b6fd65b18e
* Closes: macaroni-os/mark-issues#263

Test Plan
========
* Doit
```
 ╰ $ doit
INFO     Autogen: dev-db/sqlite (latest)                                                                                                                                                                                     
INFO     Created: sqlite-3.48.0.ebuild     
```
* Make it available in a own repo tree or by seeding into a local overlay
* Emerge it
```
Updating profiles at /etc/portage/make.profile/parent...
Updating non-funtoo repositories...
Sync successful and kits in alignment! :)

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] dev-db/sqlite-3.48.0:3::core-server-kit [3.47.2:3::core-server-kit] USE="icu readline secure-delete -debug -doc -static-libs -tcl -test -tools" 0 KiB
[ebuild     U  ] dev-python/Babel-2.17.0::python-modules-kit [2.16.0::python-modules-kit] PYTHON_TARGETS="python3_9 -python2_7 -python3_10 -python3_7 -python3_8" 9,719 KiB

Total: 2 packages (2 upgrades), Size of downloads: 9,719 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 2) dev-db/sqlite-3.48.0::core-server-kit
>>> Installing (1 of 2) dev-db/sqlite-3.48.0::core-server-kit
>>> Emerging (2 of 2) dev-python/Babel-2.17.0::python-modules-kit
>>> Installing (2 of 2) dev-python/Babel-2.17.0::python-modules-kit
>>> Jobs: 2 of 2 complete                           Load avg: 3.27, 1.88, 1.27
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.
```
* Running it
```
 $ sqlite3 
SQLite version 3.48.0 2025-01-14 11:05:00
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite> 

```