### PR TITLE
[core-kit] genkernel autogen.yaml: update source for boost tarball

### DIFF
--- a/core-kit/curated/sys-kernel/genkernel/autogen.yaml
+++ b/core-kit/curated/sys-kernel/genkernel/autogen.yaml
@@ -17,7 +17,7 @@ genkernel_rule:
           query: tags
         additional_artifacts:
           bcache-tools-1.0.8_p20141204.tar.gz: https://github.com/g2p/bcache-tools/archive/399021549984ad27bf4a13ae85e458833fe003d7.tar.gz
-          boost_1_79_0.tar.bz2: https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2
+          boost_1_79_0.tar.bz2: https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.bz2
           btrfs-progs-v6.3.2.tar.xz: https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v6.3.2.tar.xz
           busybox-1.37.0.tar.bz2: https://www.busybox.net/downloads/busybox-1.37.0.tar.bz2
           coreutils-9.4.tar.xz:  https://ftpmirror.gnu.org/coreutils/coreutils-9.4.tar.xz


### PR DESCRIPTION
This small change fixes the genkernel autogen.