### PR TITLE
[core-kit] sys-apps/sandbox Update SRC_URI in sandbox-2.24.ebuild to new location

### DIFF
--- a/core-kit/curated/sys-apps/sandbox/sandbox-2.24.ebuild
+++ b/core-kit/curated/sys-apps/sandbox/sandbox-2.24.ebuild
@@ -6,7 +6,7 @@ inherit flag-o-matic multilib-minimal multiprocessing
 
 DESCRIPTION="sandbox'd LD_PRELOAD hack"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Sandbox"
-SRC_URI="https://dev.gentoo.org/~slyfox/distfiles/${P}.tar.xz"
+SRC_URI="https://gitweb.gentoo.org/proj/sandbox.git/snapshot/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Changed SRC_URI to point to the updated sandbox repository location, switching from a tar.xz source to a tar.gz snapshot on gitweb.gentoo.org. This ensures the source aligns with the current hosting method for sandbox.

(cherry picked from commit d295f7d518219a0699b7b17f3ce4b450cca4f7aa) (cherry picked from commit 852cae5c8fca679bee4b80b88627105cc08a3168) (cherry picked from commit 08568b62d143895025a31998d38b71dbdee781fe)