### PR TITLE
[core-kit] sys-apps/miscfiles 

### DIFF
--- a/core-kit/next/sys-apps/miscfiles/autogen.yaml
+++ b/core-kit/next/sys-apps/miscfiles/autogen.yaml
@@ -1,0 +1,14 @@
+miscfiles_rule:
+  generator: miscfiles
+  packages:
+    - miscfiles:
+        cat: sys-apps
+        desc: Miscellaneous files
+        homepage: https://savannah.gnu.org/projects/miscfiles/
+        revision: 4
+        dir:
+          url: https://ftp.gnu.org/gnu/miscfiles/
+          order: asc
+          format: tar.gz
+        additional_artifacts:
+          - https://distfiles.gentoo.org/distfiles/0b/UnicodeData-10.0.0.txt.xz

--- a/core-kit/next/sys-apps/miscfiles/generators/miscfiles.py
+++ b/core-kit/next/sys-apps/miscfiles/generators/miscfiles.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import re
+
+async def generate(hub, **pkginfo):
+
+	if 'version' not in pkginfo or 'latest' in pkginfo['version']:
+		release_data = await hub.pkgtools.fetch.get_page( pkginfo['dir']['url'], is_json=False )
+		releases = re.findall(
+			f'(?<=href="{pkginfo["name"]}-)\d+(?:\.\d+)+(?=\.tar\.gz"|\.tar\.bz2"|\.tar\.xz|\.zip")',
+			release_data
+		)
+
+		if not releases:
+			raise KeyError(f"Unable to find a suitable version for {pkginfo['cat']}-{pkginfo['name']}.")
+
+		# Some directories listings are ordered ascending from oldest to newest,
+		# some list files descending from newest to oldest. We want the newest file
+		# (the first one in 'descending' listing or the last in 'ascending' ones.
+		if 'order' in pkginfo['dir'] and 'asc' in pkginfo['dir']['order']:
+			pkginfo['version'] = releases[-1]
+		else:
+			pkginfo['version'] = releases[0]
+
+	artifacts = []
+
+	artifacts.append(
+		hub.pkgtools.ebuild.Artifact(
+			url = f"{pkginfo['dir']['url']}{pkginfo['name']}-{pkginfo['version']}.{pkginfo['dir']['format']}"
+		)
+	)
+
+	if 'additional_artifacts' in pkginfo:
+		for url in pkginfo['additional_artifacts']:
+			artifacts.append(
+				hub.pkgtools.ebuild.Artifact(url)
+			)
+
+	ebuild = hub.pkgtools.ebuild.BreezyBuild(
+		**pkginfo,
+		artifacts=artifacts
+	)
+	ebuild.push()
+
+
+# vim: sw=4 ts=4 noet

--- a/core-kit/next/sys-apps/miscfiles/templates/miscfiles.tmpl
+++ b/core-kit/next/sys-apps/miscfiles/templates/miscfiles.tmpl
@@ -1,0 +1,63 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+UNI_PV="10.0.0"
+DESCRIPTION="{{desc}}"
+HOMEPAGE="{{homepage}}"
+SRC_URI="{{src_uri}}"
+
+LICENSE="GPL-2 unicode"
+SLOT="0"
+KEYWORDS="*"
+IUSE="minimal"
+
+# Collides with older versions/revisions
+RDEPEND="!<sys-freebsd/freebsd-share-7.2-r1"
+DEPEND=""
+
+src_prepare() {
+	default
+
+	mv "${WORKDIR}"/UnicodeData-${UNI_PV}.txt unicode || die
+}
+
+src_configure() {
+	econf --datadir="${EPREFIX%/}"/usr/share/misc
+}
+
+src_install() {
+	emake install DESTDIR="${D}"
+	dodoc NEWS ORIGIN README dict-README
+
+	# not sure if this is still needed ...
+	dodir /usr/share/dict
+	cd "${ED%/}"/usr/share/misc || die
+	mv $(awk '$1=="dictfiles"{$1="";$2="";print}' "${S}"/Makefile) ../dict/ || die
+	cd ../dict || die
+	ln -s web2 words || die
+	ln -s web2a extra.words || die
+
+	if use minimal ; then
+		pushd "${ED%/}"/usr/share/dict || die
+		rm -f words extra.words || die
+		gzip -9 * || die
+		ln -s web2.gz words || die
+		ln -s web2a.gz extra.words || die
+		ln -s connectives{.gz,} || die
+		ln -s propernames{.gz,} || die
+		popd || die
+		rm -r "${ED%/}"/usr/share/misc || die
+	fi
+}
+
+pkg_postinst() {
+	if [[ ${ROOT} == "/" ]] && type -P create-cracklib-dict >/dev/null ; then
+		ebegin "Regenerating cracklib dictionary"
+		create-cracklib-dict "${EPREFIX%/}"/usr/share/dict/* > /dev/null
+		eend $?
+	fi
+
+	# pkg_postinst isn't supposed to fail
+	return 0
+}

--- a/dev-kit/mark/packages.yaml
+++ b/dev-kit/mark/packages.yaml
@@ -1190,7 +1190,6 @@ packages:
   - dev-vcs/tortoisehg
   - dev-vcs/vcsh
   - sys-apps/elfix
-  - sys-apps/miscfiles
   - sys-apps/mlocate
   - sys-apps/osinfo-db
   - sys-apps/osinfo-db-tools

--- a/dev-kit/packages.yaml
+++ b/dev-kit/packages.yaml
@@ -1224,7 +1224,6 @@ packages:
   - app-misc/scrub
   - app-misc/terminal-colors
   - sys-apps/elfix
-  - sys-apps/miscfiles
   - sys-apps/mlocate
   - sys-apps/osinfo-db
   - sys-apps/osinfo-db-tools


### PR DESCRIPTION
Remove sys-apps/miscfiles from gentoo-staging package lists as it was autogened in the previous commit

The sys-apps/miscfiles package has been removed from both `packages.yaml` files. This change likely reflects its redundancy or lack of necessity in the current setup.

(cherry picked from commit 00074d8a9d7fa5a31436124a20da87f50605d35a) (cherry picked from commit 587b414a12fdbf73150a45534908a07292ab63e8) (cherry picked from commit 6d36838e14d7346c3a07b94c3934efd92b46ecf9)

Add sys-apps/miscfiles package with generator support

Introduced the sys-apps/miscfiles package using EAPI 6 with associated ebuild, generator script, and autogen.yaml. The generator handles artifact fetching and version determination, ensuring compatibility and alignment with upstream sources.

(cherry picked from commit 0e0cfc2a52b0b305dc1953706871603592f9fc05)