### PR TITLE
[core-kit] sys-devel/gnuconfig Autogen gnuconfig package and remove it from core-kit package lists

### DIFF
--- a/core-kit/mark/packages.yaml
+++ b/core-kit/mark/packages.yaml
@@ -283,7 +283,6 @@ packages:
   - sys-devel/crossdev
   - sys-devel/flex
   - sys-devel/gdb
-  - sys-devel/gnuconfig
   - sys-devel/libtool
   - sys-devel/m4
   - sys-devel/ucpp

--- a/core-kit/next/sys-devel/gnuconfig/autogen.yaml
+++ b/core-kit/next/sys-devel/gnuconfig/autogen.yaml
@@ -1,0 +1,11 @@
+gnuconfig_rule:
+  generator: dirlisting-1
+  packages:
+    - gnuconfig:
+        cat: sys-devel
+        desc: Updated config.sub and config.guess file from GNU
+        homepage: https://savannah.gnu.org/projects/config
+        dir:
+          url: https://distfiles.gentoo.org/distfiles/f9/
+          order: asc
+          format: tar.xz

--- a/core-kit/next/sys-devel/gnuconfig/templates/gnuconfig.tmpl
+++ b/core-kit/next/sys-devel/gnuconfig/templates/gnuconfig.tmpl
@@ -1,0 +1,37 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="5"
+
+inherit eutils
+
+DESCRIPTION="{{desc}}"
+HOMEPAGE="{{homepage}}"
+SRC_URI="{{src_uri}}"
+
+KEYWORDS="*"
+S="${WORKDIR}"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+src_unpack() {
+	unpack ${A}
+}
+
+src_prepare() {
+	use elibc_uclibc && sed -i 's:linux-gnu:linux-uclibc:' testsuite/config-guess.data #180637
+}
+
+src_compile() { :;}
+
+src_test() {
+	emake check
+}
+
+src_install() {
+	insinto /usr/share/${PN}
+	doins config.{sub,guess} || die
+	fperms +x /usr/share/${PN}/config.{sub,guess}
+	dodoc ChangeLog
+}

--- a/core-kit/next/sys-devel/gnuconfig/templates/gnuconfig.tmpl
+++ b/core-kit/next/sys-devel/gnuconfig/templates/gnuconfig.tmpl
@@ -1,6 +1,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI="7"
 
 inherit eutils
 
@@ -15,19 +15,12 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE=""
 
-src_unpack() {
-	unpack ${A}
-}
-
 src_prepare() {
+    default
 	use elibc_uclibc && sed -i 's:linux-gnu:linux-uclibc:' testsuite/config-guess.data #180637
 }
 
 src_compile() { :;}
-
-src_test() {
-	emake check
-}
 
 src_install() {
 	insinto /usr/share/${PN}

--- a/core-kit/packages.yaml
+++ b/core-kit/packages.yaml
@@ -87,7 +87,6 @@ packages:
   - app-eselect/eselect-blas
   - app-eselect/eselect-cblas
   - sys-devel/libtool
-  - sys-devel/gnuconfig
   - sys-devel/bison
   - sys-devel/m4
   - sys-devel/autogen


### PR DESCRIPTION
Introduce a new template for the gnuconfig package with essential build and install functions. Include autogen.yaml to define directory-based package generation for fetching and updating config files. Remove gnuconfig from gentoo-staging

(cherry picked from commit 8cb75aa9fb246776e58ce9d2c39f778181d18f88) (cherry picked from commit beab382a2e1b6cb40545faed825fb30173e4e23a) (cherry picked from commit 6d213203690fe3471a5651426ee88c9161ea4770) (cherry picked from commit 6a7967861573d9873172869ea11b2b7b30078df5)

```
pdating non-funtoo repositories...
Sync successful and kits in alignment! :)

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] sys-devel/gnuconfig-20240728::core-kit [20180101::core-kit] 0 KiB

Total: 1 package (1 upgrade), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) sys-devel/gnuconfig-20240728::core-kit
>>> Installing (1 of 1) sys-devel/gnuconfig-20240728::core-kit
>>> Jobs: 1 of 1 complete                           Load avg: 1.38, 1.91, 1.93
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.
```