### PR TITLE
[core-kit] sys-libs/libxcrypt Autogen sys-libs/libxcrypt package and remove it from gentoo-staging package lists

### DIFF
--- a/core-kit/mark/packages.yaml
+++ b/core-kit/mark/packages.yaml
@@ -431,7 +431,6 @@ packages:
   - sys-libs/libudev-compat
   - sys-libs/libunwind
   - sys-libs/libutempter
-  - sys-libs/libxcrypt
   - sys-libs/mtdev
   - sys-libs/musl
   - sys-libs/native-uuid

--- a/core-kit/next/sys-libs/libxcrypt/autogen.yaml
+++ b/core-kit/next/sys-libs/libxcrypt/autogen.yaml
@@ -1,0 +1,11 @@
+libxcrypt_github_rule:
+  generator: github-1
+  packages:
+    - libxcrypt:
+        cat: sys-libs
+        license: LGPL-2.1
+        desc: "A replacement for libcrypt with DES, MD5 and blowfish support"
+        homepage: "https://github.com/besser82/libxcrypt"
+        github:
+          user: besser82
+          query: releases

--- a/core-kit/next/sys-libs/libxcrypt/templates/libxcrypt.tmpl
+++ b/core-kit/next/sys-libs/libxcrypt/templates/libxcrypt.tmpl
@@ -1,0 +1,27 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+inherit eutils
+
+DESCRIPTION="{{desc}}"
+HOMEPAGE="{{homepage}}"
+SRC_URI="{{src_uri}}"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="*"
+IUSE=""
+
+S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
+
+src_configure() {
+    ./autogen.sh
+
+	# Do not install into /usr so that tcb and pam can use us.
+	econf --libdir=/$(get_libdir) --disable-static
+}
+
+src_install() {
+	default
+	prune_libtool_files
+}

--- a/core-kit/packages.yaml
+++ b/core-kit/packages.yaml
@@ -351,7 +351,6 @@ packages:
   - sys-libs/librtas
   - sys-libs/lib-compat
   - sys-libs/rpmatch-standalone
-  - sys-libs/libxcrypt
   - sys-libs/uid_wrapper
   - sys-libs/libspe2
   - sys-libs/csu


### PR DESCRIPTION
Introduce a new template for the sys-libs/libxcrypt package with essential build and install functions. Include autogen.yaml to define directory-based package generation for fetching and updating config files. Remove gnuconfig from gentoo-staging

(cherry picked from commit b6fd2d681fb5e8da2e46395830adb7529a665029) (cherry picked from commit bea8ffd46f88865062798217571a9fc51c680504)