### PR TITLE
[core-kit] app-misc/mime-types Autogen app-misc/mime-types package and remove it from gentoo-staging package lists

### DIFF
--- a/core-kit/mark/packages.yaml
+++ b/core-kit/mark/packages.yaml
@@ -119,7 +119,6 @@ packages:
   - app-eselect/eselect-xvmc
   - app-misc/byobu
   - app-misc/editor-wrapper
-  - app-misc/mime-types
   - app-misc/realpath
   - app-misc/vlock
   - app-portage/cfg-update

--- a/core-kit/next/app-misc/mime-types/autogen.yaml
+++ b/core-kit/next/app-misc/mime-types/autogen.yaml
@@ -1,0 +1,13 @@
+mime-types_rule:
+  generator: dirlisting-1
+  packages:
+    - mime-types:
+        cat: app-misc
+        desc: Provides /etc/mime.types file
+        homepage: https://pagure.io/mailcap
+        dir:
+          url: https://releases.pagure.org/mailcap/
+          order: asc
+          format: tar.xz
+          files:
+            - mailcap

--- a/core-kit/next/app-misc/mime-types/templates/mime-types.tmpl
+++ b/core-kit/next/app-misc/mime-types/templates/mime-types.tmpl
@@ -1,0 +1,22 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="{{desc}}"
+HOMEPAGE="{{homepage}}"
+SRC_URI="{{src_uri}}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="*"
+IUSE=""
+
+DEPEND=""
+RDEPEND=""
+
+S="${WORKDIR}/mailcap-${PV}"
+
+src_install() {
+	insinto /etc
+	doins mime.types
+}

--- a/core-kit/packages.yaml
+++ b/core-kit/packages.yaml
@@ -337,7 +337,6 @@ packages:
   - sys-block/parted
   - net-mail/mailbase
   - app-misc/editor-wrapper
-  - app-misc/mime-types
   - app-misc/realpath
   - sys-libs/pinktrace
   - sys-libs/lib-compat-loki


### PR DESCRIPTION
Introduce a new template for the app-misc/mime-types package with essential build and install functions. Include autogen.yaml to define directory-based package generation for fetching and updating config files. Remove gnuconfig from gentoo-staging

(cherry picked from commit b420f7beb7847662307aa9422db4fec151e21b5d) (cherry picked from commit cfa2606015ab07f10e30b338ce1d4fed5264cfb3)