### PR TITLE
core-kit: Autogen virtual packages

### DIFF
--- a/core-kit/autogen.kit.d/virtual.yml
+++ b/core-kit/autogen.kit.d/virtual.yml
@@ -1,0 +1,106 @@
+virtual_core:
+  generator: builtin-noop
+  template:
+    engine: helm
+
+  defaults:
+    template: ../../templates/simple.tmpl
+    category: virtual
+
+  packages:
+    - acl:
+        vars:
+          desc: Virtual for acl support (sys/acl.h)
+          iuse: static-libs
+          versions:
+            - "1"
+          rdepend: |
+            sys-apps/acl[static-libs?]
+
+    - awk:
+        vars:
+          desc: Virtual for awk implementation
+          versions:
+            - "2"
+          rdepend: |
+            || (
+              sys-apps/gawk
+              sys-apps/busybox
+            )
+
+    - libc:
+        vars:
+          desc: Virtual for C library
+          versions:
+            - "2"
+          rdepend: |
+            elibc_glibc? ( sys-libs/glibc )
+            elibc_musl? ( sys-libs/musl )
+            elibc_uclibc? ( sys-libs/uclibc-ng )
+
+    - libelf:
+        vars:
+          desc: Virtual for libelf.so.1 provider dev-libs/elfutils
+          versions:
+            - "4"
+          rdepend: |
+            dev-libs/elfutils
+
+    # NOTE: This virtual could be a removed from the tree.
+    - libiconv:
+        vars:
+          desc: Virtual for the GNU conversion library
+          versions:
+            - "1"
+          # Don't put elibc_glibc? ( sys-libs/glibc ) to avoid
+          # circular deps between that and gcc
+          rdepend: ""
+
+    # NOTE: This virtual could be a removed from the tree.
+    - libintl:
+        vars:
+          desc: Virtual for the GNU Internationalization Library
+          versions:
+            - "1"
+          # Don't put elibc_glibc? ( sys-libs/glibc ) to avoid
+          # circular deps between that and gcc
+          rdepend: ""
+
+    - pager:
+        vars:
+          desc: Virtual for command-line pagers
+          versions:
+            - "1"
+          rdepend: |
+            || (
+              sys-apps/less
+              sys-apps/util-linux[ncurses]
+              app-editors/vim[vim-pager]
+            )
+
+    - shadow:
+        vars:
+          desc: Virtual for user account management utilities
+          # At some point we can consider to have only
+          # entities if it supplies similar features
+          versions:
+            - "1"
+          rdepend: |
+            sys-apps/shadow
+
+    - tmpfiles:
+        vars:
+          desc: Virtual to select between different tmpfiles.d handlers
+          iuse: systemd
+          versions:
+            - "3"
+          rdepend: |
+            !systemd? ( sys-apps/systemd-tmpfiles )
+            systemd? ( sys-apps/systemd )
+
+    - libffi:
+        vars:
+          desc: A virtual for the Foreign Function Interface implementation
+          versions:
+            - "3.3_rc0"
+          rdepend: ">=dev-libs/libffi-{{ .Values.version }}"

--- a/core-kit/merge.kit.d/core_autogen.yml
+++ b/core-kit/merge.kit.d/core_autogen.yml
@@ -1,8 +1,7 @@
 sources:
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
-  #commit_sha1: "1456ea54c3efae418e8de419af2ea1b66ab2cbaa"
+  branch: "mark-unstable"
 
 - name: "core-server-kit"
   url: "https://github.com/macaroni-os/core-server-kit"
@@ -535,108 +534,19 @@ target:
         - https://distfiles-flat.macaronios.org/distfiles
         - https://distfiles-flat.macaronios.org/
 
-  fixups:
-    include:
-      - dir: ../../static/licenses
-        to: licenses
-
-      - file: ../../LICENSE
-        to: LICENSE
-
-      - file: ../../.github/FUNDING.yml
-        to: .github/FUNDING.yml
-
-      - dir: ../profiles/
-        to: profiles
-
-      - dir: ../../eclass/
-        to: eclass
-
 
   atoms_defaults:
     max_versions: 3
 
   atoms:
-    - pkg: sys-devel/gcc:12.3.0
-    - pkg: sys-libs/glibc:2.2
-      conditions:
-        - '>=sys-libs/glibc-2.33-r4:2.2'
-    - pkg: sys-devel/binutils:2.40
-    - pkg: sys-libs/binutils-libs
-
-    - pkg: app-arch/brotli
-    - pkg: app-arch/bzip2
-    - pkg: app-arch/cpio
-    - pkg: app-arch/dpkg
-    - pkg: app-arch/gzip
-    - pkg: app-arch/libarchive
-    - pkg: app-arch/lz4
-    - pkg: app-arch/pax
-    - pkg: app-arch/pxz
-    - pkg: app-arch/rar
-    - pkg: app-arch/tar
-    - pkg: app-arch/snappy
-    - pkg: app-arch/unzip
-    - pkg: app-arch/xz-utils
-    - pkg: app-arch/zstd
-
-    - pkg: app-misc/ca-certificates
-    - pkg: app-misc/mime-types
-
-    - pkg: app-shells/bash
-    - pkg: app-shells/dash
-    - pkg: app-shells/tcsh
-    - pkg: app-shells/zsh
-
-    - pkg: dev-libs/libxml2:2
-    - pkg: dev-libs/libpcre
-    - pkg: dev-libs/libsigc++:2
-    - pkg: dev-libs/libsigc++:3
-    - pkg: dev-libs/elfutils
-    - pkg: dev-libs/expat
-    - pkg: dev-libs/gmp
-    - pkg: dev-libs/icu
-
-    # Python dep
-    - pkg: dev-libs/libffi
-
-    - pkg: dev-libs/libltdl
-    - pkg: dev-libs/libpcre2
-
-    - pkg: net-dns/libidn2
-
-    - pkg: sys-apps/acl
-    - pkg: sys-apps/attr
-    - pkg: sys-apps/baselayout
-    - pkg: sys-apps/coreutils
-    - pkg: sys-apps/debianutils
-    - pkg: sys-apps/diffutils
-    - pkg: sys-apps/file
-    - pkg: sys-apps/findutils
-    - pkg: sys-apps/gawk
-    - pkg: sys-apps/grep
-    - pkg: sys-apps/groff
-    - pkg: sys-apps/less
-    - pkg: sys-apps/sed
-    - pkg: sys-apps/shadow
-    - pkg: sys-apps/sysvinit
-    - pkg: sys-apps/util-linux
-    - pkg: sys-apps/which
-
-    - pkg: sys-devel/automake:1.16
-    - pkg: sys-devel/autoconf:2.69
-    - pkg: sys-devel/autoconf:latest
-    - pkg: sys-devel/autoconf-archive
-    - pkg: sys-devel/libtool:2
-    - pkg: sys-devel/gettext
-    - pkg: sys-devel/gnuconfig
-    - pkg: sys-devel/m4
-    - pkg: sys-devel/make
-    - pkg: sys-devel/patch
-
-    - pkg: sys-libs/libcap
-    - pkg: sys-libs/libcap-ng
-    - pkg: sys-libs/ncurses
-    - pkg: sys-libs/readline
-    - pkg: sys-libs/timezone-data
-    - pkg: sys-libs/zlib
+    - pkg: virtual/libffi
+    - pkg: virtual/acl
+    - pkg: virtual/awk
+    - pkg: virtual/fortran
+    - pkg: virtual/libc
+    - pkg: virtual/libelf
+    - pkg: virtual/libiconv
+    - pkg: virtual/libintl
+    - pkg: virtual/pager
+    - pkg: virtual/shadow
+    - pkg: virtual/tmpfiles

--- a/templates/simple.tmpl
+++ b/templates/simple.tmpl
@@ -3,13 +3,22 @@
 EAPI={{ .Values.eapi | default "7" }}
 
 DESCRIPTION="{{ .Values.desc }}"
+{{- if .Values.homepage | default false }}
 HOMEPAGE="{{ .Values.homepage }}"
+{{- end }}
+{{- if .Values.src_uri | default false }}
 SRC_URI="{{ .Values.src_uri }}"
+{{- end }}
 
+{{- if .Values.license | default false }}
 LICENSE="{{ .Values.license }}"
+{{- end }}
 SLOT="{{ .Values.slot | default 0 }}"
 KEYWORDS="{{ .Values.keywords | default "*" }}"
 
+{{- if .Values.iuse | default false }}
+IUSE="{{ .Values.iuse }}"
+{{- end }}
 {{- if .Values.restrict | default false }}
 RESTRICT="{{ .Values.restrict }}"
 {{- end }}
@@ -30,11 +39,8 @@ RDEPEND="{{- regexReplaceAll "\\n" .Values.rdepend "\n\t" }}
 PDEPEND="{{ regexReplaceAll "\\n" .Values.pdepend "\n\t" }}
 "
 {{- end }}
-{{- if .Values.iuse | default false }}
-IUSE="{{ .Values.iuse }}"
-{{- end }}
-{{ if .Values.body }}
+{{- if .Values.body }}
 {{ regexReplaceAll "\\n\\s\\s" .Values.body "\n\t" }}
-{{ end }}
+{{- end }}
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#298

# doit

```
$> cd core-kit
$> mark-devkit doit --specfile autogen.kit.d/virtual.yml --kitfile merge.kit.d/core_autogen.yml    
😷 Loading specfile autogen.kit.d/virtual.yml
🏰 Work directory:	workdir
🚀 Target Kit:		core-kit
🏭 [virtual_core] Processing definition ...
🏭 [virtual_core] Processing atom acl...
🍕 [acl] For package virtual/acl selected version 1
🏭 [virtual_core] Processing atom awk...
🍕 [awk] For package virtual/awk selected version 2
🏭 [virtual_core] Processing atom libc...
🍕 [libc] For package virtual/libc selected version 2
🏭 [virtual_core] Processing atom libelf...
🍕 [libelf] For package virtual/libelf selected version 4
🏭 [virtual_core] Processing atom libiconv...
🍕 [libiconv] For package virtual/libiconv selected version 1
🏭 [virtual_core] Processing atom libintl...
🍕 [libintl] For package virtual/libintl selected version 1
🏭 [virtual_core] Processing atom pager...
🍕 [pager] For package virtual/pager selected version 1
🏭 [virtual_core] Processing atom shadow...
🍕 [shadow] For package virtual/shadow selected version 1
🏭 [virtual_core] Processing atom tmpfiles...
🍕 [tmpfiles] For package virtual/tmpfiles selected version 3
🏭 [virtual_core] Processing atom libffi...
🍕 [libffi] For package virtual/libffi selected version 3.3_rc0
🎉 All done
```
