### PR TITLE
[core-kit] sys-apps/util-linux: Switch util-linux generator to GitHub-based approach

### DIFF
--- a/core-kit/mark/sys-apps/util-linux/autogen.yaml
+++ b/core-kit/mark/sys-apps/util-linux/autogen.yaml
@@ -1,9 +1,15 @@
 util-linux:
-  generator: gnu-1
+  generator: github-1
   packages:
     - util-linux:
-        base_url: https://mirrors.edge.kernel.org/pub/linux/utils/util-linux
-        dir_paths:
-          - 'v([\d.]+)'
-        compression: xz
+        cat: sys-apps
+        desc: Various useful Linux utilities
+        homepage: https://www.kernel.org/pub/linux/utils/util-linux/
+        license: GPL-2 GPL-3 LGPL-2.1 BSD-4 MIT public-domain
+        github:
+          query: tags
+          transform:
+            - kind: string
+              match: 'v'
+              replace: ''
 

--- a/core-kit/mark/sys-apps/util-linux/templates/util-linux.tmpl
+++ b/core-kit/mark/sys-apps/util-linux/templates/util-linux.tmpl
@@ -7,11 +7,11 @@ PYTHON_COMPAT=( python3+ )
 inherit autotools toolchain-funcs libtool flag-o-matic bash-completion-r1 usr-ldscript \
 	pam python-r1 multiprocessing
 
-DESCRIPTION="Various useful Linux utilities"
-HOMEPAGE="https://www.kernel.org/pub/linux/utils/util-linux/ https://github.com/karelzak/util-linux"
+DESCRIPTION="{{desc}}"
+HOMEPAGE="{{homepage}}"
 SRC_URI="{{src_uri}}"
+LICENSE="{{license}}"
 
-LICENSE="GPL-2 GPL-3 LGPL-2.1 BSD-4 MIT public-domain"
 SLOT="0"
 KEYWORDS="*"
 IUSE="audit build +caps +cramfs cryptsetup fdformat hardlink kill +logger magic ncurses nls pam python +readline rtas selinux slang static-libs su +suid tty-helpers udev unicode"


### PR DESCRIPTION

Switches the generator from gnu-1 to github-1 for util-linux, leveraging GitHub tags as the versioning source. This change simplifies version handling and aligns with updated repository structures. Metadata and configuration were adjusted to match the new generator setup.

(cherry picked from commit 2a2b33ad9285f9ec1dee481d9fe7f1e98ebc460e) (cherry picked from commit 0674c27214145e49446e82087a09ea01ccfc217d)

[core-kit] sys-apps/util-linux Update util-linux package metadata in autogen and template files

Standardize util-linux metadata by using variables in the template file for description, homepage, and license. Improved readability and maintainability by centralizing metadata definitions in `autogen.yaml`.

(cherry picked from commit 9ca6df9c92a42d78cc30d5cfd5195ba5cfa1cd9d) (cherry picked from commit 5f5dc749db934bf03ebfcdc4567cc3f7b0f7df2a)