### PR TITLE
Update util-linux template to fix build process

### DIFF
--- a/core-kit/mark/sys-apps/util-linux/templates/util-linux.tmpl
+++ b/core-kit/mark/sys-apps/util-linux/templates/util-linux.tmpl
@@ -12,6 +12,8 @@ HOMEPAGE="{{homepage}}"
 SRC_URI="{{src_uri}}"
 LICENSE="{{license}}"
 
+S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
+
 SLOT="0"
 KEYWORDS="*"
 IUSE="audit build +caps +cramfs cryptsetup fdformat hardlink kill +logger magic ncurses nls pam python +readline rtas selinux slang static-libs su +suid tty-helpers udev unicode"
@@ -69,8 +71,8 @@ pkg_pretend() {
 
 src_prepare() {
 	default
-
-	elibtoolize
+	./autogen.sh || die
+	eautoreconf
 }
 
 python_configure() {


### PR DESCRIPTION
Defined the source directory using the new GitHub paths for consistency and clarity. Replaced `elibtoolize` with `autogen.sh` and `eautoreconf` for better compatibility with the build system.