### PR TITLE
[core-kit] Update `net-misc/openssh` version pin to `9.9_p2`

### DIFF
--- a/core-kit/curated/net-misc/openssh/autogen.yaml
+++ b/core-kit/curated/net-misc/openssh/autogen.yaml
@@ -3,7 +3,7 @@ openssh:
   packages:
     - openssh:
         versions:
-          9.8_p1:
+          9.9_p2:
             template: openssh.tmpl
             keywords: "*"
 


### PR DESCRIPTION
Peripherally:  I think perhaps we should move `net-misc/openssh` into `core-server-kit`.