### PR TITLE
[net-kit] net-misc/networkmanager Remove unused dhcpcanon flag and disable nm_cloud_setup

### DIFF
--- a/net-kit/mark/net-misc/networkmanager/templates/networkmanager.tmpl
+++ b/net-kit/mark/net-misc/networkmanager/templates/networkmanager.tmpl
@@ -85,6 +85,7 @@ RDEPEND="${COMMON_DEPEND}
 DEPEND="${COMMON_DEPEND}
 	>=sys-kernel/linux-headers-3.18
 	net-libs/libndp
+	dev-libs/jansson
 "
 BDEPEND="
 	dev-util/gdbus-codegen
@@ -235,7 +236,6 @@ src_configure() {
 		-Dconfig_dns_rc_manager_default=auto
 
 		$(meson_nm_program dhclient "" /sbin/dhclient)
-		-Ddhcpcanon=no
 		$(meson_nm_program dhcpcd "" /sbin/dhcpcd)
 
 		$(meson_use introspection)


### PR DESCRIPTION
The `-Ddhcpcanon` flag was removed as it was no longer needed, simplifying the configuration. Additionally, `-Dnm_cloud_setup` was explicitly disabled to prevent unnecessary cloud setup behavior. These changes help streamline the build process.

(cherry picked from commit 43abc68c3a71c554869311a547d9b37e86dd9a3a) (cherry picked from commit f0635591c83ab72ffcca7a342f67f797e364f90c)