### PR TITLE
[core-server-kit] net-libs/deno Update Deno package metadata and cleanup build template

### DIFF
--- a/core-server-kit/curated/net-libs/deno/autogen.yaml
+++ b/core-server-kit/curated/net-libs/deno/autogen.yaml
@@ -2,6 +2,9 @@ deno:
   generator: github-1
   packages:
     - deno:
+        desc: Deno is a simple, modern and secure runtime for JavaScript and TypeScript
+        homepage: https://github.com/denoland/deno
+        license: MIT
         github:
           user: denoland
           repo: deno

--- a/core-server-kit/curated/net-libs/deno/templates/deno.tmpl
+++ b/core-server-kit/curated/net-libs/deno/templates/deno.tmpl
@@ -4,11 +4,11 @@ EAPI=7
 
 inherit cargo
 
-DESCRIPTION="{{description}}"
-HOMEPAGE="https://github.com/{{github_user}}/{{github_repo}}"
-SRC_URI="{{src_uri}}"
+DESCRIPTION="{{ desc }}"
+HOMEPAGE="{{ homepage }}"
+SRC_URI="{{ src_uri }}"
+LICENSE="{{ license }}"
 
-LICENSE="MIT"
 SLOT="0"
 KEYWORDS="*"
 
@@ -20,20 +20,18 @@ BDEPEND="
 	virtual/rust
 "
 
+RESTRICT="network-sandbox"
+
+S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
+
 src_unpack() {
 	cargo_src_unpack
-	rm -rf ${S}
-	mv ${WORKDIR}/{{github_user}}-{{github_repo}}-* ${S} || die
 }
 
 src_compile() {
 	# Don't try to fetch prebuilt V8, build it instead
 	export V8_FROM_SOURCE=1
-
-	# Resolves to /usr/lib64/llvm/<version>
-	export CLANG_BASE_PATH="$(readlink -f -- "$(dirname -- $(clang --print-prog-name=clang))/..")"
-
-	cargo_src_compile
+    cargo_src_compile
 }
 
 src_install() {


### PR DESCRIPTION
Added description, homepage, and license fields to Deno's metadata. Adjusted template to utilize new metadata properties and simplified the src_unpack function. Minor cleanup performed for consistent formatting and redundancy removal.

(cherry picked from commit 482672db28cab2e70009a2f9ea6d2723bee17bdd) (cherry picked from commit e76293f20a3dd3922368ce11e8e1fed174c04320)