### PR TITLE
[games-kit] Remove failing patch from Odamex autogen.yaml block

### DIFF
--- a/games-kit/curated/autogen.yaml
+++ b/games-kit/curated/autogen.yaml
@@ -67,8 +67,6 @@ doom_github_rule:
         github:
           user: odamex
           repo: odamex
-        patches:
-          - 10.3.0-unbundle-fltk.patch
         versions:
           latest:
             github:


### PR DESCRIPTION
Odamex updated to `odamex-11.0.0` the other day, and an old patch in our tree (to use the system `fltk`) is failing.  Removing it solves the problem.