### PR TITLE
[python-modules-kit] dev-util/scons Remove unused 'pypi_name' from Scons entry.

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -679,7 +679,6 @@ dev_python_compat_rule:
     - scons:
         du_pep517: generator
         blocker: '!<dev-util/scons-4.0.0'
-        pypi_name: SCons
         desc: Extensible Python-based build utility
         homepage: https://www.scons.org/
         license: MIT


### PR DESCRIPTION
The 'pypi_name' field was redundant and has been removed for clarity and consistency. This simplifies the metadata and avoids unnecessary information in the YAML file.

(cherry picked from commit 8537d7053db95f34b3041482097430d04043502e) (cherry picked from commit 2529597d3199b0e367b270440bd260d97d85732e)

 Closes: macaroni-os/mark-issues#304