### PR TITLE
[core-kit] dev-vcs/git Update documentation file formats to .adoc in git templates

### DIFF
--- a/core-kit/curated/dev-vcs/git/templates/git.tmpl
+++ b/core-kit/curated/dev-vcs/git/templates/git.tmpl
@@ -300,7 +300,7 @@ src_install() {
 	local d
 	for d in / /howto/ /technical/ ; do
 		docinto ${d}
-		dodoc Documentation${d}*.txt
+		dodoc Documentation${d}*.adoc
 		if use doc ; then
 			docinto ${d}/html
 			dodoc Documentation${d}*.html
@@ -341,7 +341,7 @@ src_install() {
 		git_emake install-man install-html || die "Failed to emake install-html install-man for git-subtree"
 	fi
 	newdoc README README.git-subtree
-	dodoc git-subtree.txt
+	dodoc git-subtree.adoc
 	popd &>/dev/null || die
 
 	# diff-highlight
@@ -351,12 +351,12 @@ src_install() {
 	# git-jump
 	exeinto /usr/libexec/git-core/
 	doexe contrib/git-jump/git-jump
-	newdoc contrib/git-jump/README git-jump.txt
+	newdoc contrib/git-jump/README git-jump.adoc
 
 	# git-contacts
 	exeinto /usr/libexec/git-core/
 	doexe contrib/contacts/git-contacts
-	dodoc contrib/contacts/git-contacts.txt
+	dodoc contrib/contacts/git-contacts.adoc
 
 	if use gnome-keyring ; then
 		pushd contrib/credential/libsecret &>/dev/null || die


### PR DESCRIPTION


Replaced references to .txt files with .adoc counterparts for git-subtree, git-jump, and git-contacts documentation in the template. This ensures consistency with the updated file formats and improves maintainability. Replaced `.txt` with `.adoc` in documentation processing to align with updated file formats. Ensures compatibility with the new documentation standards and prevents potential file mismatches.

(cherry picked from commit 8c4d3f072cf44dc2d6886f958078177463b1fd13) (cherry picked from commit a4321796ffaacd4bf39cc95cd4a08e60ee0d05df) (cherry picked from commit 70b27dab733ebe5b0d6ad4b1509f910aaa5aeef4) (cherry picked from commit b834a51286abae78bc76afd7ec5e407919aa8afc)