### PR TITLE
[python-modules-kit] Autogen jinja2

### DIFF
--- a/python-modules-kit/autogen.kit.d/python.yml
+++ b/python-modules-kit/autogen.kit.d/python.yml
@@ -17,6 +17,43 @@ hatchling_modules:
         vars:
           license: MIT
 
+flit_modules:
+  generator: builtin-pypi
+  template:
+    engine: j2cli
+
+  defaults:
+    category: dev-python
+    template: "templates/pypi-generic.tmpl"
+    vars:
+      du_pep517: flit
+    python_compat: "python3+"
+
+  packages:
+
+    - jinja:
+        pypi_name: jinja2
+        pydeps:
+          py:all:build:
+            - markupsafe
+          py:all:
+            - markupsafe
+        vars:
+          desc: A full-featured template engine for Python
+          homepage: https://palletsprojects.com/p/jinja/ https://pypi.org/project/Jinja2/
+          license: BSD
+          body: |
+            src_prepare() {
+              # avoid unnecessary dep on extra sphinxcontrib modules
+              sed -i '/sphinxcontrib.log_cabinet/ d' docs/conf.py || die
+              distutils-r1_src_prepare
+            }
+            pkg_postinst() {
+              if ! has_version dev-python/Babel; then
+                elog "For i18n support, please emerge dev-python/Babel."
+              fi
+            }
+
 standalone_modules:
   generator: builtin-pypi
   template:
@@ -30,6 +67,8 @@ standalone_modules:
     python_compat: "python3+"
 
   packages:
+
+
     - yarl:
         pydeps:
           py:all:build:

--- a/python-modules-kit/autogen.kit.d/templates/pypi-generic.tmpl
+++ b/python-modules-kit/autogen.kit.d/templates/pypi-generic.tmpl
@@ -83,8 +83,8 @@ PATCHES=(
 )
 
 {%- endif %}
-{%- if S is defined %}
-S="{{ S }}"
+{%- if s is defined %}
+S="{{ s }}"
 {%- else %}
 S="${WORKDIR}/{{pypi_name}}-{{pypi_version}}"
 {%- endif %}

--- a/python-modules-kit/merge.kit.d/base.yml
+++ b/python-modules-kit/merge.kit.d/base.yml
@@ -91,7 +91,6 @@ target:
     - pkg: dev-python/installer
     - pkg: dev-python/ipaddress
     - pkg: dev-python/j2cli
-    - pkg: dev-python/jinja
     - pkg: dev-python/jsonpatch
     - pkg: dev-python/jsonpointer
     - pkg: dev-python/jsonschema

--- a/python-modules-kit/merge.kit.d/python_autogen.yml
+++ b/python-modules-kit/merge.kit.d/python_autogen.yml
@@ -13,5 +13,6 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: dev-python/jinja
     - pkg: dev-python/yarl
     - pkg: dev-python/propcache


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#311

doit:
```
$ mark-devkit doit --specfile autogen.kit.d/python.yml --kitfile merge.kit.d/python_autogen.yml            --pkg jinja
😷 Loading specfile autogen.kit.d/python.yml
🏰 Work directory:	workdir
🚀 Target Kit:		python-modules-kit
🏭 [hatchling_modules] Processing definition ...
🏭 [flit_modules] Processing definition ...
🏭 [flit_modules] Processing atom jinja...
🍕 [jinja] For package dev-python/jinja selected version 3.1.6
🏭 [standalone_modules] Processing definition ...
🎉 All done
```

testing:
```
>>> Installing (1 of 1) dev-python/jinja-3.1.6::python-modules-kit
 * For i18n support, please emerge dev-python/Babel.

>>> Recording dev-python/jinja in "world" favorites file...

 * Messages for package dev-python/jinja-3.1.6:
```