### PR TITLE
[python-modules-kit] Add dev-python/falcon package

### DIFF
--- a/python-modules-kit/autogen.kit.d/python.yml
+++ b/python-modules-kit/autogen.kit.d/python.yml
@@ -83,6 +83,14 @@ setuptools_modules:
               distutils-r1_python_compile
             }
 
+    - falcon:
+        vars:
+          license: Apache-2.0
+        pydeps:
+          py:all:build:
+            - wheel
+            - cython
+
 standalone_modules:
   generator: builtin-pypi
   template:

--- a/python-modules-kit/merge.kit.d/python_autogen.yml
+++ b/python-modules-kit/merge.kit.d/python_autogen.yml
@@ -13,6 +13,8 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: dev-python/dependency-injection
+    - pkg: dev-python/falcon
     - pkg: dev-python/jinja
     - pkg: dev-python/yarl
     - pkg: dev-python/propcache


### PR DESCRIPTION
doit:

```
$ mark-devkit doit --specfile autogen.kit.d/python.yml --kitfile merge.kit.d/python_autogen.yml            --pkg falcon
😷 Loading specfile autogen.kit.d/python.yml
🏰 Work directory:	workdir
🚀 Target Kit:		python-modules-kit
🏭 [hatchling_modules] Processing definition ...
🏭 [flit_modules] Processing definition ...
🏭 [setuptools_modules] Processing definition ...
🏭 [setuptools_modules] Processing atom falcon...
🍕 [falcon] For package dev-python/falcon selected version 4.0.2
🏭 [standalone_modules] Processing definition ...
🎉 All done

```

Closes: macaroni-os/mark-issues#315