### PR TITLE
[python-modules-kit] Add `du_pep517: generator` to `yq` YAML block

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -1575,6 +1575,7 @@ simple_python_autogen_rule:
             - dev-python/xmltodict
         rdepend: |
           app-misc/jq
+        du_pep517: generator
 
 misc:
   defaults:


### PR DESCRIPTION
This patch fixes `yq` emerging.