### PR TITLE
[net-kit] Pin www-apps/gitea-1.23.4 until we have go-1.23.7

### DIFF
--- a/net-kit/curated/www-apps/gitea/autogen.yaml
+++ b/net-kit/curated/www-apps/gitea/autogen.yaml
@@ -2,6 +2,8 @@ gitea:
   generator: github-1
   packages:
     - gitea:
+        # pinned until we have >=dev-lang/go-1.23.7
+        version: 1.23.4
         github:
           user: go-gitea
           repo: gitea


### PR DESCRIPTION
This patch pins `gitea` to the last version that builds with our `go-1.23.1`.  

Closes: macaroni-os/mark-issues#319.