### PR TITLE
[core-kit] sys-apps/sandbox   Autogen sandbox from Github

### DIFF
--- a/core-kit/curated/sys-apps/sandbox/autogen.yaml
+++ b/core-kit/curated/sys-apps/sandbox/autogen.yaml
@@ -1,0 +1,16 @@
+sandbox_rule:
+  generator: github-1
+  packages:
+    - sandbox:
+        cat: sys-apps
+        desc: sandbox'd LD_PRELOAD hack
+        homepage: https://wiki.gentoo.org/wiki/Project:Sandbox
+        license: GPL-2
+        github:
+          user: gentoo
+          query: tags
+          transform:
+            - kind: string
+              match: "v"
+              replace: ""
+          select: '2.\d+'

--- a/core-kit/curated/sys-apps/sandbox/templates/sandbox.tmpl
+++ b/core-kit/curated/sys-apps/sandbox/templates/sandbox.tmpl
@@ -2,16 +2,18 @@
 
 EAPI=7
 
-inherit flag-o-matic multilib-minimal multiprocessing
+inherit flag-o-matic multiprocessing
 
-DESCRIPTION="sandbox'd LD_PRELOAD hack"
-HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Sandbox"
-SRC_URI="https://gitweb.gentoo.org/proj/sandbox.git/snapshot/${P}.tar.gz"
+DESCRIPTION="{{desc}}"
+HOMEPAGE="{{homepage}}"
+SRC_URI="{{src_uri}}"
+LICENSE="{{license}}"
 
-LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="*"
 IUSE=""
+
+S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
 
 DEPEND="app-arch/xz-utils
 	>=app-misc/pax-utils-0.1.19" #265376
@@ -26,7 +28,7 @@ sandbox_death_notice() {
 
 src_prepare() {
 	default
-
+    ./autogen.sh
 	# sandbox uses `__asm__ (".symver "...` which does
 	# not play well with gcc's LTO: https://gcc.gnu.org/PR48200
 	append-flags -fno-lto
@@ -35,20 +37,20 @@ src_prepare() {
 	./autogen.sh
 }
 
-multilib_src_configure() {
+src_configure() {
 	filter-lfs-flags #90228
 
 	ECONF_SOURCE="${S}" econf
 }
 
-multilib_src_test() {
+src_test() {
 	# Default sandbox build will run with --jobs set to # cpus.
 	# -j1 to prevent test faiures caused by file descriptor
 	# injection GNU make does.
 	emake -j1 check TESTSUITEFLAGS="--jobs=$(makeopts_jobs)"
 }
 
-multilib_src_install_all() {
+src_install_all() {
 	echo 'CONFIG_PROTECT_MASK="/etc/sandbox.d"'> "${T}"/09sandbox
 	doenvd "${T}"/09sandbox
 


### PR DESCRIPTION
    Added a 'select' field to refine version matching logic. This ensures the correct version format (2.x) is targeted for processing.

(cherry picked from commit f6fbe71f1e15a2b5645173dc2f7fff59edf2a6da) (cherry picked from commit cb627294fd51eee081a79f86b320c844f30c203f)

[core-kit] sys-apps/sandbox Update sandbox package to use GitHub for source management

Switched source management from static tarball URI to GitHub-based fetching with tag filtering and transformation for versioning. Adjusted template to set source directory path accordingly and removed the obsolete Manifest file.

(cherry picked from commit 4be4b372b6c0b3aaf03d4c6e5743ab72de8ca612)

(cherry picked from commit 1ba4a31b494c715a3173b34b40fe98baf8749c87)

[core-kit] sys-apps/sandbox Update sys-apps/sandbox to version 2.39 with templated ebuild.

Replaced the static sandbox-2.24.ebuild with a dynamic ebuild template and autogen.yaml for easier maintenance. Updated metadata, source URI, and checksum to reflect the new version.

(cherry picked from commit 3ca52f9430875c969f91a7a5583459cc219d7d64)

(cherry picked from commit 8d7be5775d1480bc070c2b6cb0ea9df5e22ee28f)