### PR TITLE
[lang-kit] dev-lang/go Unmask Go 1.24.1 in autogen.yaml

### DIFF
--- a/lang-kit/curated/dev-lang/autogen.yaml
+++ b/lang-kit/curated/dev-lang/autogen.yaml
@@ -7,6 +7,8 @@ go_gen:
   packages:
     - go:
         versions:
+          1.24.1:
+            unmasked: True
           1.23.1:
             unmasked: True
           1.22.7:


### PR DESCRIPTION
Added Go version 1.24.1 to the unmasked list for use in curated builds. This ensures availability for dependencies and updates compatibility with the latest version.

(cherry picked from commit 650b715b645cdf6ea0944b2ccd69400278e6a7df) (cherry picked from commit 2ae65ec15959bf6b5200f16ee17b96616de03769)