### PR TITLE
[core-gl-kit] app-emulation/libnvidia-container Fix build issue with libnvidia-container on Go 1.24

### DIFF
--- a/core-gl-kit/curated/app-emulation/libnvidia-container/files/libnvidia-container-1.17.4-go-1.24.patch
+++ b/core-gl-kit/curated/app-emulation/libnvidia-container/files/libnvidia-container-1.17.4-go-1.24.patch
@@ -1,0 +1,48 @@
+https://patch-diff.githubusercontent.com/raw/NVIDIA/libnvidia-container/pull/297.patch
+
+From 1c680195fdc85948d635286b72a6ad9f823b5987 Mon Sep 17 00:00:00 2001
+From: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
+Date: Thu, 13 Feb 2025 10:18:59 +0100
+Subject: [PATCH] Fix building with Go 1.24
+
+Go 1.24 does not allow defining methods on C types anymore, so make convert a function, not a method.
+
+Fixes the following error when building with Go 1.24:
+`./main.go:35:10: cannot define new methods on non-local type CDeviceRule`
+
+Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
+---
+ src/nvcgo/main.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/nvcgo/main.go b/src/nvcgo/main.go
+index 1523a06d..ed43be8e 100644
+--- a/src/nvcgo/main.go
++++ b/src/nvcgo/main.go
+@@ -32,7 +32,7 @@ func main() {}
+ type CDeviceRule = C.struct_device_rule
+ 
+ // Convert a C-based DeviceRule to a Go-based cgroup.DeviceRule
+-func (r *CDeviceRule) convert() cgroup.DeviceRule {
++func convert(r *CDeviceRule) cgroup.DeviceRule {
+ 	return cgroup.DeviceRule{
+ 		Allow:  bool(r.allow),
+ 		Type:   C.GoString(r._type),
+@@ -67,7 +67,7 @@ func GetDeviceCGroupMountPath(version C.int, procRootPath *C.char, pid C.pid_t,
+ 		return -1
+ 	}
+ 	*cgroupMountPath = C.CString(p)
+-	*cgroupRootPrefix= C.CString(r)
++	*cgroupRootPrefix = C.CString(r)
+ 
+ 	return 0
+ }
+@@ -100,7 +100,7 @@ func AddDeviceRules(version C.int, cgroupPath *C.char, crules []CDeviceRule, rer
+ 
+ 	rules := make([]cgroup.DeviceRule, len(crules))
+ 	for i, cr := range crules {
+-		rules[i] = cr.convert()
++		rules[i] = convert(&cr)
+ 	}
+ 
+ 	err = api.AddDeviceRules(C.GoString(cgroupPath), rules)

--- a/core-gl-kit/curated/app-emulation/libnvidia-container/templates/libnvidia-container.tmpl
+++ b/core-gl-kit/curated/app-emulation/libnvidia-container/templates/libnvidia-container.tmpl
@@ -35,6 +35,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-1.17.4-go-1.24.patch"
+)
+
 post_src_unpack() {
 	# Rename the main source directory to the expected name
 	mv {{ github_user }}-{{ github_repo }}* "${S}" || die

--- a/core-gl-kit/curated/app-emulation/libnvidia-container/templates/libnvidia-container.tmpl
+++ b/core-gl-kit/curated/app-emulation/libnvidia-container/templates/libnvidia-container.tmpl
@@ -35,10 +35,6 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-PATCHES=(
-	"${FILESDIR}/${PN}-1.17.4-go-1.24.patch"
-)
-
 post_src_unpack() {
 	# Rename the main source directory to the expected name
 	mv {{ github_user }}-{{ github_repo }}* "${S}" || die
@@ -57,6 +53,11 @@ post_src_unpack() {
 }
 
 src_prepare() {
+	local gov=$(go version | awk '{ print $3 }' | sed -e 's/go//' -e 's/.[0-9]*$//' -e 's/^[0-9].//')
+    if [ $gov -ge 24 ] ; then
+        eapply ${FILESDIR}/${PN}-1.17.4-go-1.24.patch
+    fi
+
 	default
 
 	# Don't fetch the sources for nvidia-modprobe and elftoolchain from the internet during src_compile()


### PR DESCRIPTION
Updated libnvidia-container to resolve build errors caused by Go 1.24 no longer supporting methods on C types. Introduced a patch converting the method to a standalone function and updated the package template to apply the patch. This ensures compatibility with Go 1.24 and successful builds.

(cherry picked from commit bb95958a3f144fe030597e8334c5bdfec40cf671) (cherry picked from commit cf61c08ca27a4bc25fa109bc366863973e28c3b8)