### PR TITLE
[media-kit] media-video/ffmpeg Add patch to fix SHR type mismatch in FFmpeg 4.3.1

### DIFF
--- a/media-kit/curated/media-video/ffmpeg/ffmpeg-4.3.1-r2.ebuild
+++ b/media-kit/curated/media-video/ffmpeg/ffmpeg-4.3.1-r2.ebuild
@@ -312,7 +312,8 @@ PATCHES=(
 	"${FILESDIR}"/chromium-r1.patch
 	"${FILESDIR}"/${PN}-4.3-fix-build-without-SSSE3.patch
 	"${FILESDIR}"/${PN}-4.3-altivec-novsx-yuv2rgb.patch
-	"${FILESDIR}"/ffmpeg-4.3.1-new-sdl2-version-scheme.patch
+	"${FILESDIR}"/${PN}-4.3.1-new-sdl2-version-scheme.patch
+	"${FILESDIR}"/${PN}-4.3.1-fix-shr-type-mismatch.patch
 )
 
 MULTILIB_WRAPPED_HEADERS=(

--- a/media-kit/curated/media-video/ffmpeg/files/ffmpeg-4.3.1-fix-shr-type-mismatch.patch
+++ b/media-kit/curated/media-video/ffmpeg/files/ffmpeg-4.3.1-fix-shr-type-mismatch.patch
@@ -1,0 +1,58 @@
+index 6298f5ed1983b84205479d1a714bd657435789f9..ca7e2dffc1076f82d2cabf55eae0681adbdcfb96 100644 (file)
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }


### PR DESCRIPTION
This patch addresses type mismatches in shift operations within FFmpeg's assembly code on x86. It introduces conditional handling for constant and non-constant shifts to ensure correctness. The ebuild is updated to include the new patch.

(cherry picked from commit 9c24ad51ee2ecb2d509fa8627cc9aedd6fcea701) (cherry picked from commit 5d4d03f40899d4697c93a9bc711a36c32bdc8527)