### PR TITLE
[core-kit] dev-util/meson Update Meson template and autogen for dynamic metadata inclusion

### DIFF
--- a/core-kit/curated/dev-util/meson/autogen.yaml
+++ b/core-kit/curated/dev-util/meson/autogen.yaml
@@ -2,11 +2,12 @@ meson_rule:
   generator: github-1
   packages:
     - meson:
+        cat: dev-util
+        description: Open source build system
+        homepage: https://mesonbuild.com/
+        license: Apache-2.0
         github:
           user: mesonbuild
           query: tags
           tarball: "meson-{version}.tar.gz"
         template: meson.tmpl
-        versions:
-          latest: {}
-          0.59.1: {}

--- a/core-kit/curated/dev-util/meson/templates/meson.tmpl
+++ b/core-kit/curated/dev-util/meson/templates/meson.tmpl
@@ -6,19 +6,16 @@ DISTUTILS_USE_SETUPTOOLS="rdepend"
 
 inherit bash-completion-r1 distutils-r1 toolchain-funcs
 
-SRC_URI="{{src_uri}}"
+DESCRIPTION="{{ desc }}"
+HOMEPAGE="{{ homepage }}"
+SRC_URI="{{ src_uri }}"
+LICENSE="{{ license }}"
+
 KEYWORDS="*"
 
-DESCRIPTION="Open source build system"
-HOMEPAGE="https://mesonbuild.com/"
-
-LICENSE="Apache-2.0"
 SLOT="0"
 
-src_unpack() {
-	unpack ${A}
-	mv "${WORKDIR}"/mesonbuild-* "${S}"
-}
+S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
 
 python_install_all() {
 	distutils-r1_python_install_all


### PR DESCRIPTION
Changed Meson template to dynamically include metadata like description, homepage, and license. Updated autogen.yaml to remove hardcoded versions and align with the new template structure.

(cherry picked from commit 4f24dc3754833f5a6f77d8ebdea67617377518e8)