### PR TITLE
[core-kit] app-emulation/runc Refine version extraction logic in runc autogen.yaml

### DIFF
--- a/core-kit/curated/app-emulation/runc/autogen.yaml
+++ b/core-kit/curated/app-emulation/runc/autogen.yaml
@@ -6,3 +6,8 @@ runc:
           user: opencontainers
           repo: runc
           query: releases
+          transform:
+            - kind: string
+              match: "v"
+              replace: ""
+          select: '\d+.\d+.\d+'


### PR DESCRIPTION
Updated the autogen.yaml file for runc to include a transform step, stripping the "v" prefix and selecting semantic version numbers. This ensures accurate version parsing during release queries.

(cherry picked from commit ff9f6713a706f47e3b25f482520fef130abdfc74) (cherry picked from commit b2b6636c7288edecbe752814bc770f327f328321)