### PR TITLE
[core-kit] dev-util/ninja Add autogen and template files for ninja package

### DIFF
--- a/core-kit/curated/dev-util/ninja/autogen.yaml
+++ b/core-kit/curated/dev-util/ninja/autogen.yaml
@@ -1,0 +1,15 @@
+ninja_rule:
+  generator: github-1
+  packages:
+    - ninja:
+        cat: dev-util
+        description: A small build system similar to make
+        homepage: hhttps://ninja-build.org/
+        license: Apache-2.0
+        github:
+          user: ninja-build
+          query: tags
+          transform:
+            - kind: string
+              match: 'v'
+              replace: ''

--- a/core-kit/curated/dev-util/ninja/templates/ninja.tmpl
+++ b/core-kit/curated/dev-util/ninja/templates/ninja.tmpl
@@ -1,0 +1,121 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3+ )
+
+inherit bash-completion-r1 elisp-common python-any-r1 toolchain-funcs
+
+DESCRIPTION="{{ desc }}"
+HOMEPAGE="{{ homepage }}"
+SRC_URI="{{ src_uri }}"
+LICENSE="{{ license }}"
+
+KEYWORDS="*"
+SLOT="0"
+IUSE="doc emacs test vim-syntax"
+
+S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
+
+BDEPEND="
+	${PYTHON_DEPS}
+	dev-util/re2c
+	doc? (
+		app-text/asciidoc
+		app-doc/doxygen
+		dev-libs/libxslt
+	)
+	test? ( dev-cpp/gtest )
+"
+RDEPEND="
+	emacs? ( virtual/emacs )
+	vim-syntax? (
+		|| (
+			app-editors/vim
+			app-editors/gvim
+		)
+	)
+"
+
+run_for_build() {
+	if tc-is-cross-compiler; then
+		local -x AR=$(tc-getBUILD_AR)
+		local -x CXX=$(tc-getBUILD_CXX)
+		local -x CFLAGS=
+		local -x CXXFLAGS=${BUILD_CXXFLAGS}
+		local -x LDFLAGS=${BUILD_LDFLAGS}
+	fi
+	echo "$@" >&2
+	"$@"
+}
+
+src_compile() {
+	tc-export AR CXX
+
+	# configure.py uses CFLAGS instead of CXXFLAGS
+	export CFLAGS=${CXXFLAGS}
+
+	run_for_build ${EPYTHON} configure.py --bootstrap --verbose || die
+
+	if tc-is-cross-compiler; then
+		mv ninja ninja-build || die
+		${EPYTHON} configure.py || die
+		./ninja-build -v ninja || die
+	else
+		ln ninja ninja-build || die
+	fi
+
+	if use doc; then
+		./ninja-build -v doxygen manual || die
+	fi
+
+	if use emacs; then
+		elisp-compile misc/ninja-mode.el || die
+	fi
+}
+
+src_test() {
+	if ! tc-is-cross-compiler; then
+		# Bug 485772
+		ulimit -n 2048
+		./ninja -v ninja_test || die
+		./ninja_test || die
+	fi
+}
+
+src_install() {
+	dodoc README.md
+	if use doc; then
+		docinto html
+		dodoc -r doc/doxygen/html/.
+		dodoc doc/manual.html
+	fi
+	dobin ninja
+
+	newbashcomp misc/bash-completion "${PN}"
+
+	if use vim-syntax; then
+		insinto /usr/share/vim/vimfiles/syntax/
+		doins misc/ninja.vim
+
+		echo 'au BufNewFile,BufRead *.ninja set ft=ninja' > "${T}/ninja.vim"
+		insinto /usr/share/vim/vimfiles/ftdetect
+		doins "${T}/ninja.vim"
+	fi
+
+	insinto /usr/share/zsh/site-functions
+	newins misc/zsh-completion _ninja
+
+	if use emacs; then
+		cd misc || die
+		elisp-install ninja ninja-mode.el* || die
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/core-kit/curated/dev-util/ninja/templates/ninja.tmpl
+++ b/core-kit/curated/dev-util/ninja/templates/ninja.tmpl
@@ -13,7 +13,7 @@ LICENSE="{{ license }}"
 
 KEYWORDS="*"
 SLOT="0"
-IUSE="doc emacs test vim-syntax"
+IUSE="doc emacs vim-syntax"
 
 S="${WORKDIR}/{{ github_user }}-{{ github_repo }}-{{ sha[:7] }}"
 
@@ -25,7 +25,6 @@ BDEPEND="
 		app-doc/doxygen
 		dev-libs/libxslt
 	)
-	test? ( dev-cpp/gtest )
 "
 RDEPEND="
 	emacs? ( virtual/emacs )
@@ -71,15 +70,6 @@ src_compile() {
 
 	if use emacs; then
 		elisp-compile misc/ninja-mode.el || die
-	fi
-}
-
-src_test() {
-	if ! tc-is-cross-compiler; then
-		# Bug 485772
-		ulimit -n 2048
-		./ninja -v ninja_test || die
-		./ninja_test || die
 	fi
 }
 


### PR DESCRIPTION


Introduce an autogen YAML and template for the `dev-util/ninja` package configuration. This integrates the necessary build, test, and install processes, including support for optional features like documentation, Emacs, and Vim syntax enhancements.

(cherry picked from commit 0f34a7482448c92ffe303315d0578204c8da982f)