### PR TITLE
[core-kit] sys-fs/xfsprogs autogen

### DIFF
--- a/core-kit/curated/sys-fs/xfsprogs/autogen.yaml
+++ b/core-kit/curated/sys-fs/xfsprogs/autogen.yaml
@@ -1,0 +1,12 @@
+xfsprogs_rule:
+  generator: dirlisting-1
+  packages:
+    - xfsprogs:
+        cat: sys-fs
+        desc: xfs filesystem utilities
+        homepage: https://xfs.wiki.kernel.org/
+        license: LGPL-2.1
+        dir:
+          url: https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/
+          order: asc
+          format: tar.xz

--- a/core-kit/curated/sys-fs/xfsprogs/templates/xfsprogs.tmpl
+++ b/core-kit/curated/sys-fs/xfsprogs/templates/xfsprogs.tmpl
@@ -1,0 +1,74 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs systemd usr-ldscript
+
+
+DESCRIPTION="{{ desc }}"
+HOMEPAGE="{{ homepage }}"
+SRC_URI="{{ src_uri }}"
+LICENSE="{{ license }}"
+
+SLOT="0"
+KEYWORDS="*"
+IUSE="icu libedit nls static-libs"
+
+LIB_DEPEND=">=sys-apps/util-linux-2.17.2[static-libs(+)]
+	icu? ( dev-libs/icu:=[static-libs(+)] )
+	libedit? ( dev-libs/libedit )
+	dev-libs/inih
+	dev-libs/userspace-rcu"
+RDEPEND="${LIB_DEPEND//\[static-libs(+)]}
+	!<sys-fs/xfsdump-3"
+DEPEND="${RDEPEND}
+	nls? ( sys-devel/gettext )"
+
+src_prepare() {
+	default
+
+	# Clear out -static from all flags since we want to link against dynamic xfs libs.
+	sed -i \
+		-e "/^PKG_DOC_DIR/s:@pkg_name@:${PF}:" \
+		include/builddefs.in || die
+	# Don't install compressed docs
+	sed 's@\(CHANGES\)\.gz[[:space:]]@\1 @' -i doc/Makefile || die
+	find -name Makefile -exec \
+		sed -i -r -e '/^LLDFLAGS [+]?= -static(-libtool-libs)?$/d' {} +
+}
+
+src_configure() {
+	export DEBUG=-DNDEBUG
+	export OPTIMIZER=${CFLAGS}
+	unset PLATFORM # if set in user env, this breaks configure
+
+	local myconf=(
+		--disable-lto #655638
+		--localstatedir="${EPREFIX}/var"
+		--with-crond-dir="${EPREFIX}/etc/cron.d"
+		--with-systemd-unit-dir="$(systemd_get_systemunitdir)"
+		$(use_enable icu libicu)
+		$(use_enable nls gettext)
+		$(use_enable libedit editline)
+		$(use_enable static-libs static)
+	)
+
+	econf "${myconf[@]}"
+
+	MAKEOPTS+=" V=1"
+}
+
+src_install() {
+	emake DIST_ROOT="${ED}" install
+	# parallel install fails on this target for >=xfsprogs-3.2.0
+	emake -j1 DIST_ROOT="${ED}" install-dev
+
+    rmdir "${ED}"/var/lib/xfsprogs "${ED}"/var/lib || die
+
+	# handle is for xfsdump, the rest for xfsprogs
+	gen_usr_ldscript handle xfs xlog frog
+	# removing unnecessary .la files if not needed
+	if ! use static-libs ; then
+		find "${ED}" -name '*.la' -delete || die
+	fi
+}


### PR DESCRIPTION
Add userspace-rcu as a dependency for xfsprogs

This change adds dev-libs/userspace-rcu to the LIB_DEPEND list in the xfsprogs template. This ensures proper functionality by including all necessary dependencies for building and running xfsprogs.

(cherry picked from commit 79ad9346f646dac556b3999a3d54fb2677ed9eca) (cherry picked from commit 430d5e4e1d738c0db6a4db3560ac8713037b1176)

[core-kit] sys-fs/xfsprogs Add inih as a dependency for xfsprogs

This change adds the dev-libs/inih library to the dependencies in the xfsprogs template. It ensures the required library is available for proper functionality. No existing dependencies were modified aside from this addition.

(cherry picked from commit e702eb0571fbedae7cefdc5788090baf4f02902c) (cherry picked from commit 8e30da4f3044cfb6b5e839cb271b2ec9eb75f69b)

[core-kit] sys-fs/xfsprogs  Add xfsprogs template and autogen.yaml for package setup

Introduce the xfsprogs build template to support building and configuring the xfs filesystem utilities. Add the autogen.yaml file to automate package metadata management, including license, homepage, and source directory details.

(cherry picked from commit 92a968688480f8137d0ab2b2e3a7afbda62720e7) (cherry picked from commit eced536e129c4be464a625a1b56383e5b1021f34)