### PR TITLE
[games-kit] games-fps/xonotic Fix NoneType error in Xonotic autogen link parsing

### DIFF
--- a/games-kit/curated/games-fps/xonotic/autogen.py
+++ b/games-kit/curated/games-fps/xonotic/autogen.py
@@ -14,9 +14,10 @@ async def generate(hub, **pkginfo):
 	)
 
 	link_matches = (
-		src_pattern.match(link.get("href")) for link in autobuild_soup.find_all("a")
+		src_pattern.match(link.get("href")) for link in autobuild_soup.find_all("a") if link.get("href")
 	)
 	valid_matches = (match.groups() for match in link_matches if match)
+
 
 	target_filename, target_version = max(
 		valid_matches,


### PR DESCRIPTION

Added a conditional check to avoid NoneType errors when accessing link attributes. This improves robustness during the parsing of autobuild links.

(cherry picked from commit f80defd446661b757306a9b1c4d56136b94d38c5) (cherry picked from commit 1624511f62b77a38a9be94a23130b1bc99d28eef)