### PR TITLE
[media-kit] media-gfx/exiv2 Add app-arch/brotli dependency to exiv2 t…

### DIFF
--- a/media-kit/mark/media-gfx/exiv2/autogen.yaml
+++ b/media-kit/mark/media-gfx/exiv2/autogen.yaml
@@ -1,0 +1,11 @@
+exiv2_rule:
+  generator: github-1
+  packages:
+    - exiv2:
+        cat: media-gfx
+        desc: EXIF, IPTC and XMP metadata C++ library and command line utility
+        homepage: https://www.exiv2.org/
+        license: GPL-2
+        github:
+          user: Exiv2
+          query: releases

--- a/media-kit/mark/media-gfx/exiv2/templates/exiv2.tmpl
+++ b/media-kit/mark/media-gfx/exiv2/templates/exiv2.tmpl
@@ -16,8 +16,7 @@ S="${WORKDIR}/{{github_user}}-{{github_repo}}-{{sha[:7]}}"
 
 SLOT="0/$(ver_cut 1-2)"
 KEYWORDS="*"
-IUSE="+bmff doc examples nls +png test webready +xmp"
-RESTRICT="!test? ( test )"
+IUSE="+bmff doc examples nls +png webready +xmp"
 
 BDEPEND="
 	doc? (
@@ -41,8 +40,6 @@ RDEPEND="
 	)
 	xmp? ( dev-libs/expat )
 "
-DEPEND="${DEPEND}
-	test? ( dev-cpp/gtest )"
 
 DOCS=( README.md doc/ChangeLog doc/cmd.txt )
 
@@ -73,7 +70,6 @@ src_configure() {
 		-DEXIV2_ENABLE_BMFF=$(usex bmff)
 		$(echo -DEXIV2_BUILD_EXIV2_COMMAND=NO)
 		$(echo -DEXIV2_BUILD_DOC=$(usex doc))
-		$(echo -DEXIV2_BUILD_UNIT_TESTS=$(usex test))
 		-DCMAKE_INSTALL_DOCDIR="${EPREFIX}"/usr/share/doc/${PF}/html
 	)
 
@@ -84,11 +80,6 @@ src_compile() {
 	cmake_src_compile
 
 	use doc && eninja doc
-}
-
-src_test() {
-	cd "${BUILD_DIR}"/bin || die
-	./unit_tests || die "Failed to run tests"
 }
 
 src_install() {

--- a/media-kit/mark/media-gfx/exiv2/templates/exiv2.tmpl
+++ b/media-kit/mark/media-gfx/exiv2/templates/exiv2.tmpl
@@ -68,9 +68,9 @@ src_configure() {
 		-DEXIV2_ENABLE_WEBREADY=$(usex webready)
 		-DEXIV2_ENABLE_XMP=$(usex xmp)
 		-DEXIV2_ENABLE_BMFF=$(usex bmff)
-		$(echo -DEXIV2_BUILD_EXIV2_COMMAND=NO)
-		$(echo -DEXIV2_BUILD_DOC=$(usex doc))
-		$(echo -DEXIV2_BUILD_UNIT_TESTS=NO)
+		-DEXIV2_BUILD_EXIV2_COMMAND=NO
+		-DEXIV2_BUILD_DOC=$(usex doc)
+		-DEXIV2_BUILD_UNIT_TESTS=NO
 		-DCMAKE_INSTALL_DOCDIR="${EPREFIX}"/usr/share/doc/${PF}/html
 	)
 

--- a/media-kit/mark/media-gfx/exiv2/templates/exiv2.tmpl
+++ b/media-kit/mark/media-gfx/exiv2/templates/exiv2.tmpl
@@ -1,0 +1,106 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+
+CMAKE_ECLASS=cmake
+PYTHON_COMPAT=( python3+ )
+inherit cmake python-any-r1
+
+DESCRIPTION="{{desc}}"
+HOMEPAGE="{{homepage}}"
+SRC_URI="{{src_uri}}"
+LICENSE="{{license}}"
+
+S="${WORKDIR}/{{github_user}}-{{github_repo}}-{{sha[:7]}}"
+
+SLOT="0/$(ver_cut 1-2)"
+KEYWORDS="*"
+IUSE="+bmff doc examples nls +png test webready +xmp"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	doc? (
+		${PYTHON_DEPS}
+		app-doc/doxygen
+		dev-libs/libxslt
+		media-gfx/graphviz
+		virtual/pkgconfig
+	)
+	nls? ( sys-devel/gettext )
+	dev-libs/inih
+	app-arch/brotli
+"
+RDEPEND="
+    >=virtual/libiconv-0-r1
+	nls? ( >=virtual/libintl-0-r1 )
+	png? ( sys-libs/zlib )
+	webready? (
+		>net-libs/libssh-0.9.1[sftp]
+		net-misc/curl
+	)
+	xmp? ( dev-libs/expat )
+"
+DEPEND="${DEPEND}
+	test? ( dev-cpp/gtest )"
+
+DOCS=( README.md doc/ChangeLog doc/cmd.txt )
+
+pkg_setup() {
+	use doc && python-any-r1_pkg_setup
+}
+
+src_prepare() {
+	# FIXME @upstream:
+	einfo "Converting doc/cmd.txt to UTF-8"
+	iconv -f LATIN1 -t UTF-8 doc/cmd.txt > doc/cmd.txt.tmp || die
+	mv -f doc/cmd.txt.tmp doc/cmd.txt || die
+
+	cmake_src_prepare
+
+	sed -e "/^include.*compilerFlags/s/^/#DONT /" -i CMakeLists.txt || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_CXX_STANDARD=14
+		-DEXIV2_BUILD_SAMPLES=NO
+		-DEXIV2_ENABLE_NLS=$(usex nls)
+		-DEXIV2_ENABLE_PNG=$(usex png)
+		-DEXIV2_ENABLE_CURL=$(usex webready)
+		-DEXIV2_ENABLE_WEBREADY=$(usex webready)
+		-DEXIV2_ENABLE_XMP=$(usex xmp)
+		-DEXIV2_ENABLE_BMFF=$(usex bmff)
+		$(echo -DEXIV2_BUILD_EXIV2_COMMAND=NO)
+		$(echo -DEXIV2_BUILD_DOC=$(usex doc))
+		$(echo -DEXIV2_BUILD_UNIT_TESTS=$(usex test))
+		-DCMAKE_INSTALL_DOCDIR="${EPREFIX}"/usr/share/doc/${PF}/html
+	)
+
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_src_compile
+
+	use doc && eninja doc
+}
+
+src_test() {
+	cd "${BUILD_DIR}"/bin || die
+	./unit_tests || die "Failed to run tests"
+}
+
+src_install() {
+    cmake_src_install
+
+	use xmp && DOCS+=( doc/{COPYING-XMPSDK,README-XMP,cmdxmp.txt} )
+
+	einstalldocs
+	find "${D}" -name '*.la' -delete || die
+
+	if use examples; then
+		docinto examples
+		dodoc samples/*.cpp
+	fi
+}

--- a/media-kit/mark/media-gfx/exiv2/templates/exiv2.tmpl
+++ b/media-kit/mark/media-gfx/exiv2/templates/exiv2.tmpl
@@ -70,6 +70,7 @@ src_configure() {
 		-DEXIV2_ENABLE_BMFF=$(usex bmff)
 		$(echo -DEXIV2_BUILD_EXIV2_COMMAND=NO)
 		$(echo -DEXIV2_BUILD_DOC=$(usex doc))
+		$(echo -DEXIV2_BUILD_UNIT_TESTS=NO)
 		-DCMAKE_INSTALL_DOCDIR="${EPREFIX}"/usr/share/doc/${PF}/html
 	)
 


### PR DESCRIPTION
…emplate

This change includes app-arch/brotli as a dependency in the exiv2 template for improved functionality or compatibility. The update ensures all required libraries are correctly referenced.