### PR TITLE
[python-modules-kit] dec-python/calver Update autogen.yaml to customi…

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -2262,7 +2262,12 @@ pep517_compliance_rule:
         pydeps:
           py:all:build:
             - calver
-    - calver
+    - calver:
+        body: |
+          src_prepare() {
+            sed -i -e 's/license = "Apache-2.0"/license = { text = "Apache-2.0" }/' pyproject.toml || die
+            distutils-r1_src_prepare
+          }
     - hatch-vcs:
         pypi_name: hatch_vcs
         du_pep517: hatchling


### PR DESCRIPTION
…ze `calver` src_prepare phase

Added a custom `src_prepare` function for `calver` to modify the `pyproject.toml` file, ensuring compatibility with build processes. This includes replacing the license format to align with expected standards. See https://github.com/di/calver/pull/19

(cherry picked from commit 92312a649d86867c733bfadc4a62f78a790802c1) (cherry picked from commit 8c4f3ffe684a8ff21c9f6b80407467d754071e00)