### PR TITLE
[python-modules-kit] dev-python/markdown Add custom `src_prepare` for handling pyproject.toml modifications

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -537,6 +537,12 @@ dev_python_compat_rule:
         pydeps:
           py:3,pypy3:
             - importlib_metadata
+        body: |
+          src_prepare() {
+            sed -i -e 's/license = "BSD-3-Clause"/license = { text = "BSD-3-Clause" }/' pyproject.toml || die
+            sed -i -e '/license-files/d' pyproject.toml || die
+            distutils-r1_src_prepare
+          }
     - mako:
         blocker: "!<dev-python/mako-1.2.0-r1"
         revision:


### PR DESCRIPTION
The changes ensure the license field and related entries in pyproject.toml are correctly formatted during the preparation phase. This update aligns with build requirements and prevents potential issues with package metadata processing.