### PR TITLE
[mark-unstable] Add packages needed in `mark-xl`

### DIFF
--- a/core-server-kit/merge.kit.d/tools.yml
+++ b/core-server-kit/merge.kit.d/tools.yml
@@ -37,6 +37,19 @@ target:
 
   atoms:
 
+    - pkg: app-admin/ansible
+    - pkg: app-admin/ansible-base
+    - pkg: app-admin/awscli
+    - pkg: app-admin/awscliv2
+    - pkg: app-admin/cloud-init
+    - pkg: app-admin/sudo
+    - pkg: app-admin/logrotate
+    - pkg: app-admin/metalog
+    - pkg: app-admin/openrc-settingsd
+    - pkg: app-admin/rsyslog
+    - pkg: app-admin/syslog-ng
+    - pkg: app-admin/sysstat
+
     - pkg: app-arch/gcab
     - pkg: app-arch/lrzip
     - pkg: app-arch/lziprecover
@@ -55,22 +68,10 @@ target:
     - pkg: app-arch/zoo
     - pkg: app-arch/zopfli
 
-    - pkg: app-admin/ansible
-    - pkg: app-admin/ansible-base
-    - pkg: app-admin/awscli
-    - pkg: app-admin/awscliv2
-    - pkg: app-admin/cloud-init
-    - pkg: app-admin/sudo
-    - pkg: app-admin/logrotate
-    - pkg: app-admin/metalog
-    - pkg: app-admin/openrc-settingsd
-    - pkg: app-admin/rsyslog
-    - pkg: app-admin/syslog-ng
-    - pkg: app-admin/sysstat
-
     - pkg: app-backup/backrest
     - pkg: app-backup/borgbackup
     - pkg: app-backup/restic
+    - pkg: app-backup/rsnapshot
 
     - pkg: app-benchmarks/hyperfine
 
@@ -113,43 +114,28 @@ target:
     - pkg: dev-util/smem
     - pkg: dev-util/xdelta
 
-    - pkg: sys-block/open-iscsi
-    - pkg: sys-block/open-isns
-    - pkg: sys-block/parted
-
-    - pkg: sys-process/cronbase
-    - pkg: sys-process/cronie
-    - pkg: sys-process/criu
-    - pkg: sys-process/fcron
-    - pkg: sys-process/lsof
-    - pkg: sys-process/htop
-    - pkg: sys-process/iotop
-    - pkg: sys-process/numad
-    - pkg: sys-process/procps
-    - pkg: sys-process/procs
-    - pkg: sys-process/psmisc
-    - pkg: sys-process/procs
-    - pkg: sys-process/numactl
-    - pkg: sys-process/tini
+    - pkg: sys-apps/cpuid
+    - pkg: sys-apps/dbus
+    - pkg: sys-apps/dtc
+    - pkg: sys-apps/hdparm
+    - pkg: sys-apps/hwids
+    - pkg: sys-apps/kbd
+    - pkg: sys-apps/lsb-release
+    - pkg: sys-apps/openrc
+    - pkg: sys-apps/pciutils
+    - pkg: sys-apps/sdparm
+    - pkg: sys-apps/systemd-tmpfiles
+    - pkg: sys-apps/texinfo
+    - pkg: sys-apps/usbutils
+    - pkg: sys-apps/usbredir
 
     - pkg: sys-auth/nss-mdns
     - pkg: sys-auth/nss-myhostname
     - pkg: sys-auth/realtime-base
 
-    - pkg: sys-apps/kbd
-
-    - pkg: sys-apps/cpuid
-    - pkg: sys-apps/dtc
-    - pkg: sys-apps/hwids
-    - pkg: sys-apps/xinetd
-    - pkg: sys-apps/lsb-release
-    - pkg: sys-apps/openrc
-    - pkg: sys-apps/pciutils
-    - pkg: sys-apps/texinfo
-    - pkg: sys-apps/usbutils
-    - pkg: sys-apps/usbredir
-    - pkg: sys-apps/dbus
-    - pkg: sys-apps/systemd-tmpfiles
+    - pkg: sys-block/open-iscsi
+    - pkg: sys-block/open-isns
+    - pkg: sys-block/parted
 
     - pkg: sys-devel/bc
 
@@ -163,8 +149,24 @@ target:
     - pkg: sys-libs/tevent
 
     - pkg: sys-power/cpupower
+    - pkg: sys-power/powertop
+
+    - pkg: sys-process/at
+    - pkg: sys-process/cronbase
+    - pkg: sys-process/cronie
+    - pkg: sys-process/criu
+    - pkg: sys-process/fcron
+    - pkg: sys-process/lsof
+    - pkg: sys-process/htop
+    - pkg: sys-process/iotop
+    - pkg: sys-process/numactl
+    - pkg: sys-process/numad
+    - pkg: sys-process/parallel
+    - pkg: sys-process/procps
+    - pkg: sys-process/procs
+    - pkg: sys-process/psmisc
+    - pkg: sys-process/tini
 
     - pkg: virtual/cron
     - pkg: virtual/logger
     - pkg: virtual/service-manager
-

--- a/dev-kit/merge.kit.d/base.yml
+++ b/dev-kit/merge.kit.d/base.yml
@@ -70,14 +70,15 @@ target:
 
     - pkg: app-misc/rlwrap
     - pkg: app-misc/asciinema
-    - pkg: app-misc/jq
-    - pkg: app-misc/yq-go
     - pkg: app-misc/google-cloud-sdk
+    - pkg: app-misc/jq
     - pkg: app-misc/neofetch
     - pkg: app-misc/mkcert
+    - pkg: app-misc/rlwrap
     - pkg: app-misc/scrub
     - pkg: app-misc/tmux
     - pkg: app-misc/tmux-mem-cpu-load
+    - pkg: app-misc/yq-go
 
     - pkg: app-text/asciidoc
     - pkg: app-text/manpager
@@ -171,6 +172,7 @@ target:
     - pkg: dev-libs/libmaxminddb
     - pkg: dev-libs/libmspack
     - pkg: dev-libs/librdkafka
+    - pkg: dev-libs/libsecp256k1
     - pkg: dev-libs/libsodium
     - pkg: dev-libs/libsigsegv
     - pkg: dev-libs/libtommath

--- a/net-kit/merge.kit.d/base.yml
+++ b/net-kit/merge.kit.d/base.yml
@@ -34,16 +34,16 @@ target:
 
   atoms:
 
+    - pkg: mail-client/alpine
     - pkg: mail-client/thunderbird-bin
 
+    - pkg: mail-filter/bogofilter
+    - pkg: mail-filter/spamassassin
 
     - pkg: mail-mta/postfix
     - pkg: mail-mta/ssmtp
     - pkg: mail-mta/nullmailer
     - pkg: mail-mta/sendmail
-
-    - pkg: mail-filter/bogofilter
-    - pkg: mail-filter/spamassassin
 
     - pkg: net-mail/dovecot
     - pkg: net-mail/mailbase
@@ -55,6 +55,7 @@ target:
     - pkg: net-analyzer/hping
     - pkg: net-analyzer/macchanger
     - pkg: net-analyzer/net-snmp
+    - pkg: net-analyzer/nettop
     - pkg: net-analyzer/openbsd-netcat
     - pkg: net-analyzer/rrdtool
     - pkg: net-analyzer/fail2ban
@@ -88,9 +89,10 @@ target:
     - pkg: net-firewall/conntrack-tools
     - pkg: net-firewall/ebtables
     - pkg: net-firewall/firewalld
+    - pkg: net-firewall/ipset
     - pkg: net-firewall/iptables
     - pkg: net-firewall/nftables
-    - pkg: net-firewall/ipset
+    - pkg: net-firewall/shorewall
 
     - pkg: net-fs/libnfs
     - pkg: net-fs/minio
@@ -129,6 +131,7 @@ target:
     - pkg: net-misc/socat
     - pkg: net-misc/stunnel
     - pkg: net-misc/sshpass
+    - pkg: net-misc/tigervnc
     - pkg: net-misc/whois
 
     - pkg: net-wireless/crda
@@ -138,6 +141,7 @@ target:
     - pkg: net-wireless/wavemon
 
     - pkg: net-p2p/rtorrent
+    - pkg: net-p2p/syncthing
 
     - pkg: net-print/cups
     - pkg: net-print/cups-filters
@@ -242,4 +246,3 @@ target:
     - pkg: net-misc/yt-dlp
 
     - pkg: www-apps/karma-bin
-

--- a/perl-kit/merge.kit.d/perl.yml
+++ b/perl-kit/merge.kit.d/perl.yml
@@ -30,118 +30,50 @@ target:
 
     - pkg: dev-lang/perl
 
-    - pkg: dev-perl/Authen-SASL
-    - pkg: dev-perl/Canary-Stability
-    - pkg: dev-perl/Crypt-PasswdMD5
-    - pkg: dev-perl/Digest-SHA1
-    - pkg: dev-perl/Digest-HMAC
-    - pkg: dev-perl/Error
-    - pkg: dev-perl/File-BaseDir
-    - pkg: dev-perl/File-DesktopEntry
-    - pkg: dev-perl/File-MimeInfo
-    - pkg: dev-perl/IPC-System-Simple
-    - pkg: dev-perl/JSON
-    - pkg: dev-perl/JSON-XS
-    - pkg: dev-perl/Locale-gettext
-    - pkg: dev-perl/LWP-Protocol-https
-    - pkg: dev-perl/Module-Build
-    - pkg: dev-perl/Net-DBus
-    - pkg: dev-perl/Pod-Parser
-    - pkg: dev-perl/X11-Protocol
-    - pkg: dev-perl/XML-LibXML
-    - pkg: dev-perl/XML-NamespaceSupport
-    - pkg: dev-perl/XML-Parser
-    - pkg: dev-perl/XML-Twig
-    - pkg: dev-perl/XML-SAX
-    - pkg: dev-perl/XML-SAX-Base
-
-    - pkg: dev-perl/IO-Socket-SSL
-    - pkg: dev-perl/MIME-Charset
-    - pkg: dev-perl/MailTools
-    - pkg: dev-perl/Net-SSLeay
-    - pkg: dev-perl/SGMLSpm
-    - pkg: dev-perl/TermReadKey
-    - pkg: dev-perl/Text-CharWidth
-    - pkg: dev-perl/Text-Iconv
-    - pkg: dev-perl/Text-Unidecode
-    - pkg: dev-perl/Text-WrapI18N
-    - pkg: dev-perl/Text-CSV
-    - pkg: dev-perl/Tie-IxHash
-    - pkg: dev-perl/Types-Serialiser
-    - pkg: dev-perl/TimeDate
-    - pkg: dev-perl/Unicode-EastAsianWidth
-    - pkg: dev-perl/Unicode-LineBreak
-    - pkg: dev-perl/URI
-    - pkg: dev-perl/XML-XPath
-    - pkg: dev-perl/YAML-Tiny
-    - pkg: dev-perl/libintl-perl
-    - pkg: dev-perl/common-sense
-
-    - pkg: dev-perl/Devel-Caller
-    - pkg: dev-perl/Variable-Magic
-    - pkg: dev-perl/MRO-Compat
-    - pkg: dev-perl/Spreadsheet-ParseExcel
-    - pkg: dev-perl/App-pwhich
-    - pkg: dev-perl/Exception-Class
-    - pkg: dev-perl/Sub-Quote
-    - pkg: dev-perl/Package-Stash-XS
-    - pkg: dev-perl/Module-Runtime
-    - pkg: dev-perl/IO-stringy
-    - pkg: dev-perl/Package-Stash
-    - pkg: dev-perl/Data-OptList
-    - pkg: dev-perl/Sub-Install
-    - pkg: dev-perl/File-Which
-    - pkg: dev-perl/Sub-Identify
-    - pkg: dev-perl/Eval-Closure
-    - pkg: dev-perl/File-HomeDir
-    - pkg: dev-perl/Crypt-RC4
-    - pkg: dev-perl/Digest-Perl-MD5
-    - pkg: dev-perl/Class-Data-Inheritable
-    - pkg: dev-perl/namespace-clean
-    - pkg: dev-perl/PadWalker
-    - pkg: dev-perl/Perl-Tidy
-    - pkg: dev-perl/B-Hooks-EndOfScope
-    - pkg: dev-perl/Devel-LexAlias
-    - pkg: dev-perl/Role-Tiny
-    - pkg: dev-perl/Dist-CheckConflicts
-    - pkg: dev-perl/Params-ValidationCompiler
-    - pkg: dev-perl/Try-Tiny
-    - pkg: dev-perl/Ref-Util-XS
-    - pkg: dev-perl/Sub-Exporter
-    - pkg: dev-perl/Sub-Name
-    - pkg: dev-perl/Devel-GlobalDestruction
-    - pkg: dev-perl/Jcode
-    - pkg: dev-perl/namespace-autoclean
-    - pkg: dev-perl/OLE-StorageLite
-    - pkg: dev-perl/Text-CSV_XS
-    - pkg: dev-perl/Sub-Exporter-Progressive
-    - pkg: dev-perl/Params-Util
-    - pkg: dev-perl/Unicode-Map
-    - pkg: dev-perl/Test-Fatal
-    - pkg: dev-perl/Tk
-    - pkg: dev-perl/Ref-Util
-    - pkg: dev-perl/Devel-StackTrace
-    - pkg: dev-perl/Module-Implementation
-    - pkg: dev-perl/Specio
-
     - pkg: dev-perl/Algorithm-Diff
     - pkg: dev-perl/AnyEvent
     - pkg: dev-perl/AnyEvent-I3
+    - pkg: dev-perl/App-pwhich
     - pkg: dev-perl/AppConfig
+    - pkg: dev-perl/Authen-SASL
+    - pkg: dev-perl/B-Hooks-EndOfScope
     - pkg: dev-perl/BSD-Resource
+    - pkg: dev-perl/Canary-Stability
+    - pkg: dev-perl/Class-Data-Inheritable
     - pkg: dev-perl/Crypt-OpenSSL-Bignum
     - pkg: dev-perl/Crypt-OpenSSL-RSA
     - pkg: dev-perl/Crypt-OpenSSL-Random
+    - pkg: dev-perl/Crypt-PasswdMD5
+    - pkg: dev-perl/Crypt-RC4
     - pkg: dev-perl/DBD-Pg
     - pkg: dev-perl/DBD-SQLite
     - pkg: dev-perl/DBD-mysql
     - pkg: dev-perl/DBI
+    - pkg: dev-perl/Data-OptList
+    - pkg: dev-perl/Date-Calc
     - pkg: dev-perl/Date-Manip
+    - pkg: dev-perl/Devel-Caller
     - pkg: dev-perl/Devel-CheckLib
+    - pkg: dev-perl/Devel-GlobalDestruction
+    - pkg: dev-perl/Devel-LexAlias
+    - pkg: dev-perl/Devel-Size
+    - pkg: dev-perl/Devel-StackTrace
+    - pkg: dev-perl/Digest-HMAC
+    - pkg: dev-perl/Digest-Perl-MD5
+    - pkg: dev-perl/Digest-SHA1
+    - pkg: dev-perl/Dist-CheckConflicts
     - pkg: dev-perl/Encode-Detect
     - pkg: dev-perl/Encode-Locale
+    - pkg: dev-perl/Error
+    - pkg: dev-perl/Eval-Closure
+    - pkg: dev-perl/Exception-Class
     - pkg: dev-perl/ExtUtils-PkgConfig
+    - pkg: dev-perl/File-BaseDir
+    - pkg: dev-perl/File-DesktopEntry
+    - pkg: dev-perl/File-HomeDir
     - pkg: dev-perl/File-Listing
+    - pkg: dev-perl/File-MimeInfo
+    - pkg: dev-perl/File-Which
     - pkg: dev-perl/GD
     - pkg: dev-perl/Geo-IP
     - pkg: dev-perl/HTML-Parser
@@ -154,36 +86,110 @@ target:
     - pkg: dev-perl/HTTP-Negotiate
     - pkg: dev-perl/IO-HTML
     - pkg: dev-perl/IO-Socket-INET6
+    - pkg: dev-perl/IO-Socket-SSL
+    - pkg: dev-perl/IO-stringy
+    - pkg: dev-perl/IPC-System-Simple
+    - pkg: dev-perl/JSON
+    - pkg: dev-perl/JSON-XS
+    - pkg: dev-perl/Jcode
     - pkg: dev-perl/LWP-MediaTypes
+    - pkg: dev-perl/LWP-Protocol-https
+    - pkg: dev-perl/Lchown
+    - pkg: dev-perl/Locale-gettext
     - pkg: dev-perl/Log-Dispatch
+    - pkg: dev-perl/MIME-Charset
     - pkg: dev-perl/MIME-tools
+    - pkg: dev-perl/MRO-Compat
     - pkg: dev-perl/Mail-DKIM
     - pkg: dev-perl/Mail-SPF
+    - pkg: dev-perl/MailTools
+    - pkg: dev-perl/Module-Build
+    - pkg: dev-perl/Module-Implementation
+    - pkg: dev-perl/Module-Runtime
     - pkg: dev-perl/Net-CIDR-Lite
+    - pkg: dev-perl/Net-DBus
     - pkg: dev-perl/Net-DNS
     - pkg: dev-perl/Net-DNS-Resolver-Programmable
     - pkg: dev-perl/Net-Daemon
     - pkg: dev-perl/Net-HTTP
     - pkg: dev-perl/Net-Patricia
+    - pkg: dev-perl/Net-SSLeay
     - pkg: dev-perl/NetAddr-IP
+    - pkg: dev-perl/OLE-StorageLite
+    - pkg: dev-perl/Package-Stash
+    - pkg: dev-perl/Package-Stash-XS
+    - pkg: dev-perl/PadWalker
+    - pkg: dev-perl/Params-Util
+    - pkg: dev-perl/Params-ValidationCompiler
     - pkg: dev-perl/Parse-Yapp
     - pkg: dev-perl/Path-Tiny
+    - pkg: dev-perl/Perl-Tidy
     - pkg: dev-perl/PlRPC
     - pkg: dev-perl/Pod-LaTeX
+    - pkg: dev-perl/Pod-Parser
+    - pkg: dev-perl/Ref-Util
+    - pkg: dev-perl/Ref-Util-XS
+    - pkg: dev-perl/Role-Tiny
+    - pkg: dev-perl/SGMLSpm
     - pkg: dev-perl/Socket6
+    - pkg: dev-perl/Specio
+    - pkg: dev-perl/Spreadsheet-ParseExcel
+    - pkg: dev-perl/Sub-Exporter
+    - pkg: dev-perl/Sub-Exporter-Progressive
+    - pkg: dev-perl/Sub-Identify
+    - pkg: dev-perl/Sub-Install
+    - pkg: dev-perl/Sub-Name
+    - pkg: dev-perl/Sub-Quote
+    - pkg: dev-perl/Sys-CPU
+    - pkg: dev-perl/Sys-MemInfo
     - pkg: dev-perl/Template-Toolkit
+    - pkg: dev-perl/TermReadKey
+    - pkg: dev-perl/Test-Fatal
     - pkg: dev-perl/Text-Autoformat
+    - pkg: dev-perl/Text-CSV
+    - pkg: dev-perl/Text-CSV_XS
+    - pkg: dev-perl/Text-CharWidth
+    - pkg: dev-perl/Text-Iconv
     - pkg: dev-perl/Text-Reform
+    - pkg: dev-perl/Text-Unidecode
+    - pkg: dev-perl/Text-WrapI18N
+    - pkg: dev-perl/Tie-IxHash
+    - pkg: dev-perl/TimeDate
+    - pkg: dev-perl/Tk
+    - pkg: dev-perl/Try-Tiny
+    - pkg: dev-perl/Types-Serialiser
+    - pkg: dev-perl/URI
+    - pkg: dev-perl/Unicode-EastAsianWidth
+    - pkg: dev-perl/Unicode-LineBreak
+    - pkg: dev-perl/Unicode-Map
+    - pkg: dev-perl/Variable-Magic
     - pkg: dev-perl/WWW-RobotRules
+    - pkg: dev-perl/X11-Protocol
+    - pkg: dev-perl/XML-LibXML
+    - pkg: dev-perl/XML-NamespaceSupport
+    - pkg: dev-perl/XML-Parser
+    - pkg: dev-perl/XML-SAX
+    - pkg: dev-perl/XML-SAX-Base
     - pkg: dev-perl/XML-SAX-Expat
     - pkg: dev-perl/XML-Simple
+    - pkg: dev-perl/XML-Twig
+    - pkg: dev-perl/XML-XPath
+    - pkg: dev-perl/YAML-Tiny
+    - pkg: dev-perl/common-sense
+    - pkg: dev-perl/libintl-perl
     - pkg: dev-perl/libwww-perl
+    - pkg: dev-perl/namespace-autoclean
+    - pkg: dev-perl/namespace-clean
 
     - pkg: perl-core/File-Temp
 
+    - pkg: virtual/perl-Archive-Tar
     - pkg: virtual/perl-CPAN-Meta
     - pkg: virtual/perl-CPAN-Meta-YAML
     - pkg: virtual/perl-Carp
+    - pkg: virtual/perl-Compress-Raw-Bzip2
+    - pkg: virtual/perl-Compress-Raw-Zlib
+    - pkg: virtual/perl-DB_File
     - pkg: virtual/perl-Data-Dumper
     - pkg: virtual/perl-Digest
     - pkg: virtual/perl-Digest-MD5
@@ -191,15 +197,19 @@ target:
     - pkg: virtual/perl-Encode
     - pkg: virtual/perl-Exporter
     - pkg: virtual/perl-ExtUtils-CBuilder
+    - pkg: virtual/perl-ExtUtils-Constant
     - pkg: virtual/perl-ExtUtils-Install
     - pkg: virtual/perl-ExtUtils-MakeMaker
     - pkg: virtual/perl-ExtUtils-Manifest
     - pkg: virtual/perl-ExtUtils-ParseXS
-    - pkg: virtual/perl-File-Spec
     - pkg: virtual/perl-File-Path
+    - pkg: virtual/perl-File-Spec
     - pkg: virtual/perl-File-Temp
     - pkg: virtual/perl-Getopt-Long
     - pkg: virtual/perl-IO
+    - pkg: virtual/perl-IO-Compress
+    - pkg: virtual/perl-IO-Socket-IP
+    - pkg: virtual/perl-IO-Zlib
     - pkg: virtual/perl-JSON-PP
     - pkg: virtual/perl-MIME-Base64
     - pkg: virtual/perl-Module-Metadata
@@ -207,27 +217,18 @@ target:
     - pkg: virtual/perl-Perl-OSType
     - pkg: virtual/perl-Pod-Parser
     - pkg: virtual/perl-Scalar-List-Utils
-    - pkg: virtual/perl-Test-Harness
-    - pkg: virtual/perl-Text-ParseWords
-    - pkg: virtual/perl-Term-ANSIColor
-    - pkg: virtual/perl-Time-HiRes
-    - pkg: virtual/perl-parent
-    - pkg: virtual/perl-podlators
-    - pkg: virtual/perl-version
-    - pkg: virtual/perl-libnet
-
-    - pkg: virtual/perl-Archive-Tar
-    - pkg: virtual/perl-Compress-Raw-Bzip2
-    - pkg: virtual/perl-Compress-Raw-Zlib
-    - pkg: virtual/perl-DB_File
-    - pkg: virtual/perl-ExtUtils-Constant
-    - pkg: virtual/perl-IO-Compress
-    - pkg: virtual/perl-IO-Socket-IP
-    - pkg: virtual/perl-IO-Zlib
     - pkg: virtual/perl-Storable
     - pkg: virtual/perl-Sys-Syslog
+    - pkg: virtual/perl-Term-ANSIColor
+    - pkg: virtual/perl-Test-Harness
     - pkg: virtual/perl-Test-Simple
+    - pkg: virtual/perl-Text-ParseWords
     - pkg: virtual/perl-Text-Tabs+Wrap
+    - pkg: virtual/perl-Time-HiRes
     - pkg: virtual/perl-Time-Local
     - pkg: virtual/perl-XSLoader
     - pkg: virtual/perl-if
+    - pkg: virtual/perl-libnet
+    - pkg: virtual/perl-parent
+    - pkg: virtual/perl-podlators
+    - pkg: virtual/perl-version

--- a/security-kit/merge.kit.d/security.yml
+++ b/security-kit/merge.kit.d/security.yml
@@ -40,8 +40,9 @@ target:
     max_versions: 3
 
   atoms:
-
     - pkg: app-admin/makepasswd
+    - pkg: app-admin/pwgen
+    - pkg: app-admin/sshguard
 
     - pkg: app-antivirus/lkrg
 
@@ -88,6 +89,9 @@ target:
     - pkg: net-libs/liboauth
     - pkg: net-libs/mbedtls
     - pkg: net-libs/gnutls
+
+    - pkg: net-proxy/privoxy
+    - pkg: net-proxy/torsocks
 
     - pkg: sys-apps/keyutils
     - pkg: sys-apps/bolt

--- a/text-kit/merge.kit.d/common.yml
+++ b/text-kit/merge.kit.d/common.yml
@@ -26,13 +26,6 @@ target:
 
   atoms:
 
-    - pkg: app-i18n/unicode-emoji
-
-    - pkg: app-doc/xmltoman
-    - pkg: app-doc/doxygen
-
-    - pkg: app-text/asciidoctor
-
     - pkg: app-dicts/aspell-en
     - pkg: app-dicts/aspell-sl
     - pkg: app-dicts/aspell-no
@@ -70,34 +63,26 @@ target:
     - pkg: app-dicts/aspell-fo
     - pkg: app-dicts/aspell-fr
 
+    - pkg: app-doc/xmltoman
+    - pkg: app-doc/doxygen
 
+    - pkg: app-i18n/unicode-emoji
+
+    - pkg: app-text/a2ps
+    - pkg: app-text/asciidoctor
+    - pkg: app-text/aspell
+    - pkg: app-text/bdf2psf
     - pkg: app-text/convertlit
+    - pkg: app-text/discount
+    - pkg: app-text/djvu
+    - pkg: app-text/dos2unix
+    - pkg: app-text/dvipng
     - pkg: app-text/ebook-tools
     - pkg: app-text/editorconfig-core-c
     - pkg: app-text/dvipsk
-    - pkg: app-text/xmlto
-    - pkg: app-text/ghostscript-gpl
-    - pkg: app-text/libpaper
-    - pkg: app-text/mandoc
-    - pkg: app-text/poppler
-    - pkg: app-text/pandoc-bin
-    - pkg: app-text/qpdf
-    - pkg: app-text/yelp-tools
-    - pkg: app-text/tree
-    - pkg: app-text/sgml-common
-
-    - pkg: dev-libs/kpathsea
-
-    - pkg: gnome-extra/yelp-xsl
-
-    - pkg: app-text/a2ps
-    - pkg: app-text/aspell
-    - pkg: app-text/bdf2psf
-    - pkg: app-text/discount
-    - pkg: app-text/djvu
-    - pkg: app-text/dvipng
     - pkg: app-text/enchant
     - pkg: app-text/evince
+    - pkg: app-text/ghostscript-gpl
     - pkg: app-text/gnome-doc-utils
     - pkg: app-text/gspell
     - pkg: app-text/gtkspell
@@ -116,27 +101,38 @@ target:
     - pkg: app-text/libmwaw
     - pkg: app-text/libnumbertext
     - pkg: app-text/libodfgen
+    - pkg: app-text/libpaper
     - pkg: app-text/libqxp
     - pkg: app-text/libspectre
     - pkg: app-text/libstaroffice
     - pkg: app-text/libwpd
     - pkg: app-text/libwpg
     - pkg: app-text/libwps
+    - pkg: app-text/mandoc
     - pkg: app-text/mythes
     - pkg: app-text/openjade
+    - pkg: app-text/pandoc-bin
+    - pkg: app-text/poppler
     - pkg: app-text/poppler-data
     - pkg: app-text/ps2pkm
     - pkg: app-text/psutils
+    - pkg: app-text/qpdf
     - pkg: app-text/rarian
     - pkg: app-text/rman
     - pkg: app-text/scrollkeeper-dtd
+    - pkg: app-text/sgml-common
     - pkg: app-text/t1utils
     - pkg: app-text/teckit
     - pkg: app-text/texlive-core
     - pkg: app-text/tidy-html5
+    - pkg: app-text/tree
     - pkg: app-text/wdiff
     - pkg: app-text/xhtml1
+    - pkg: app-text/xmlto
     - pkg: app-text/xournal
+    - pkg: app-text/yelp-tools
 
+    - pkg: dev-libs/kpathsea
     - pkg: dev-libs/ptexenc
 
+    - pkg: gnome-extra/yelp-xsl


### PR DESCRIPTION
Note that I alphabetized some of the packages in the YAML, in the blocks that I touched.

```
core-server-kit:
- app-benchmarks/iozone
- net-fs/autofs
- sys-apps/dool
- sys-apps/logwatch
- sys-apps/hdparm
- sys-apps/sdparm
- sys-backup/rsnapshot
- sys-fs/sysfsutils
- sys-power/powertop
- sys-process/at
- sys-process/parallel
- sys-process/schedtool

dev-kit:
- dev-libs/libsecp256k1
- app-misc/rlwrap

net-kit:
- app-admin/ulogd
- mail-client/alpine
- net-analyzer/nettop
- net-firewall/shorewall
- net-misc/tigervnc
- net-p2p/syncthing

security-kit:
- app-admin/pwgen
- app-admin/sshguard
- net-proxy/privoxy
- net-proxy/torsocks

text-kit:
- app-text/dos2unix
```