### PR TITLE
[core-kit] app-misc/ca-certificates Add --root option to update-ca-ce…

### DIFF
--- a/core-kit/curated/app-misc/ca-certificates/files/ca-certificates-20150426-root.patch
+++ b/core-kit/curated/app-misc/ca-certificates/files/ca-certificates-20150426-root.patch
@@ -1,5 +1,5 @@
-add a --root option so we can generate with DESTDIR installs
-
+diff --git a/image/usr/sbin/update-ca-certificates b/image/usr/sbin/update-ca-certificates
+index 91d8024..f35b89f 100755
 --- a/image/usr/sbin/update-ca-certificates
 +++ b/image/usr/sbin/update-ca-certificates
 @@ -30,6 +30,8 @@ LOCALCERTSDIR=/usr/local/share/ca-certificates
@@ -11,7 +11,7 @@ add a --root option so we can generate with DESTDIR installs
  
  while [ $# -gt 0 ];
  do
-@@ -59,13 +61,25 @@ do
+@@ -59,6 +61,12 @@ do
      --hooksdir)
        shift
        HOOKSDIR="$1";;
@@ -21,6 +21,12 @@ add a --root option so we can generate with DESTDIR installs
 +      # This gets us from $CERTSCONF to $CERTSDIR.
 +      RELPATH="../../.."
 +      ROOT=$(readlink -f "$1");;
+     --sysroot)
+       shift
+       SYSROOT="$1"
+@@ -68,12 +76,18 @@ do
+       ETCCERTSDIR="$1/${ETCCERTSDIR}"
+       HOOKSDIR="$1/${HOOKSDIR}";;
      --help|-h|*)
 -      echo "$0: [--verbose] [--fresh]"
 +      echo "$0: [--verbose] [--fresh] [--root <dir>]"
@@ -38,7 +44,7 @@ add a --root option so we can generate with DESTDIR installs
  if [ ! -s "$CERTSCONF" ]
  then
    fresh=1
-@@ -94,7 +107,7 @@ add() {
+@@ -102,7 +116,7 @@ add() {
                                                    -e 's/,/_/g').pem"
    if ! test -e "$PEM" || [ "$(readlink "$PEM")" != "$CERT" ]
    then


### PR DESCRIPTION
…rtificates script

Introduce a --root parameter to support certificate generation during DESTDIR installations. Adjusted the script to manage relative paths and updated the help output accordingly.

(cherry picked from commit 3ab6fb7fe41cbc6040111550c67796dc67b85ed8) (cherry picked from commit 20f6448f779de92c535a02461502c822d5ea83c8)

```
Sync successful and kits in alignment! :)

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] app-misc/ca-certificates-20250419::core-kit [20241223::core-kit] 0 KiB

Total: 1 package (1 upgrade), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) app-misc/ca-certificates-20250419::core-kit
>>> Installing (1 of 1) app-misc/ca-certificates-20250419::core-kit
>>> Jobs: 1 of 1 complete                           Load avg: 1.01, 1.33, 1.51

 * Messages for package app-misc/ca-certificates-20250419:
```