### PR TITLE
Remove failing optional gsm from sox

### DIFF
--- a/media-kit/curated/media-sound/sox/sox-14.4.2-r2.ebuild
+++ b/media-kit/curated/media-sound/sox/sox-14.4.2-r2.ebuild
@@ -25,7 +25,6 @@ src_unpack() {
 
 RDEPEND="
 	dev-libs/libltdl:0=
-	>=media-sound/gsm-1.0.12-r1
 	alsa? ( media-libs/alsa-lib )
 	amr? ( media-libs/opencore-amr )
 	ao? ( media-libs/libao )


### PR DESCRIPTION
When testing the initial Qt6 templates, qtspeech pulled in media-sound/gsm via media-sound/sox.
gsm failed to merge and is an optional library in sox. This PR removes gsm from the sox ebuild.