### PR TITLE
[python-modules-kit] dev-python/trio Add custom src_prepare for dev-p…

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -1669,6 +1669,12 @@ io_stuff_rule:
           - outcome
           - sniffio
           - exceptiongroup
+        body: |
+          src_prepare() {
+            sed -i -e 's/license = "MIT OR Apache-2.0"/license = { text = "MIT OR Apache-2.0" }/' pyproject.toml || die
+            sed -i -e '/license-files/d' pyproject.toml || die
+            distutils-r1_src_prepare
+          }
     - sortedcontainers:
         license: Apache-2.0
     - outcome:


### PR DESCRIPTION
…ython/trio in autogen.yaml

Introduced a custom `src_prepare` step for the `dev-python/trio` package in autogen.yaml. Adjusted the `license` field format and removed `license-files` from `pyproject.toml` to fix build compatibility issues.

(cherry picked from commit a102f8a2ea9ba689337803b7e8826210ae3ac67f) (cherry picked from commit bd19263ec7167b12c75b455db81ad22417a29249)