### PR TITLE
Revert "Remove failing optional gsm from sox"

### DIFF
--- a/media-kit/curated/media-sound/sox/sox-14.4.2-r2.ebuild
+++ b/media-kit/curated/media-sound/sox/sox-14.4.2-r2.ebuild
@@ -25,6 +25,7 @@ src_unpack() {
 
 RDEPEND="
 	dev-libs/libltdl:0=
+	>=media-sound/gsm-1.0.12-r1
 	alsa? ( media-libs/alsa-lib )
 	amr? ( media-libs/opencore-amr )
 	ao? ( media-libs/libao )


### PR DESCRIPTION
Reverts macaroni-os/kit-fixups#342

Using new distfiles path fix the download issue.