### PR TITLE
[core-kit] app-emulation/qemu Add sched_setattr patch for QEMU compat…

### DIFF
--- a/core-kit/curated/app-emulation/qemu/files/qemu-sched_setattr.patch
+++ b/core-kit/curated/app-emulation/qemu/files/qemu-sched_setattr.patch
@@ -1,0 +1,22 @@
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 1354e75694..caecbb765d 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -359,7 +359,8 @@ _syscall3(int, sys_sched_getaffinity, pid_t, pid, unsigned int, len,
+ #define __NR_sys_sched_setaffinity __NR_sched_setaffinity
+ _syscall3(int, sys_sched_setaffinity, pid_t, pid, unsigned int, len,
+           unsigned long *, user_mask_ptr);
+-/* sched_attr is not defined in glibc */
++/* sched_attr is not defined in glibc < 2.41 */
++#ifndef SCHED_ATTR_SIZE_VER0
+ struct sched_attr {
+     uint32_t size;
+     uint32_t sched_policy;
+@@ -372,6 +373,7 @@ struct sched_attr {
+     uint32_t sched_util_min;
+     uint32_t sched_util_max;
+ };
++#endif
+ #define __NR_sys_sched_getattr __NR_sched_getattr
+ _syscall4(int, sys_sched_getattr, pid_t, pid, struct sched_attr *, attr,
+           unsigned int, size, unsigned int, flags);

--- a/core-kit/curated/app-emulation/qemu/qemu-7.1.0.ebuild
+++ b/core-kit/curated/app-emulation/qemu/qemu-7.1.0.ebuild
@@ -270,6 +270,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-make.patch
 	"${FILESDIR}"/${PN}-7.1.0-also-build-virtfs-proxy-helper.patch
 	"${FILESDIR}"/${PN}-7.1.0-strings.patch
+	"${FILESDIR}"/${PN}-sched_setattr.patch
 )
 
 


### PR DESCRIPTION
…ibility

This patch ensures compatibility with systems using glibc versions earlier than 2.41, where `sched_attr` is not defined. It updates the QEMU build to include the necessary struct definition, preventing potential build or runtime issues.

(cherry picked from commit 6822bdd863d1b27dd0064b93d84ecf3d13b227ff) (cherry picked from commit bb98f4cebd437def8e9b42c331474f5118225aea)