### PR TITLE
[core-kit] dev-util/cmake Add patch to fix cmCurl.cxx netrc option ty…

### DIFF
--- a/core-kit/mark/dev-util/cmake/autogen.yaml
+++ b/core-kit/mark/dev-util/cmake/autogen.yaml
@@ -16,6 +16,7 @@ cmake_rule:
           - 3.9.0_rc2-FindPythonInterp.patch
           # bug 691544
           - 3.18.0-filter_distcc_warning.patch
+          - 3.24.1-curl.patch
         version: 3.24.1
         github:
           user: Kitware

--- a/core-kit/mark/dev-util/cmake/files/cmake-3.24.1-curl.patch
+++ b/core-kit/mark/dev-util/cmake/files/cmake-3.24.1-curl.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/cmCurl.cxx b/Source/cmCurl.cxx
+index b9133ed7d47..0cf8a71a72d 100644
+--- a/Source/cmCurl.cxx
++++ b/Source/cmCurl.cxx
+@@ -170,7 +170,7 @@ std::string cmCurlSetNETRCOption(::CURL* curl, const std::string& netrc_level,
+                                  const std::string& netrc_file)
+ {
+   std::string e;
+-  CURL_NETRC_OPTION curl_netrc_level = CURL_NETRC_LAST;
++  long curl_netrc_level = CURL_NETRC_LAST;
+   ::CURLcode res;
+
+   if (!netrc_level.empty()) {


### PR DESCRIPTION
…pe in CMake 3.24.1

This patch corrects the type of `curl_netrc_level` from `CURL_NETRC_OPTION` to `long`, resolving a compatibility issue in cmCurl.cxx. The autogen.yaml file was updated to include the new patch for version 3.24.1.

(cherry picked from commit c7e168e3fa739a645ab0d7f2e22667d827522382)

(cherry picked from commit 13da1023340a02281c0596466d25c36d29f772ee)