### PR TITLE
[python-modules-kit] dev-python/cryptography Update dev-python/crypto…

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -1939,7 +1939,8 @@ dev_python_simplified_rule:
             - toml
             - typing-extensions
     - cryptography:
-        version: '42.0.8'
+        du_pep517: maturin
+        version: 43.0.3
         inherit:
           - cargo
         cargo_optional: yes


### PR DESCRIPTION
…graphy to version 43.0.3

Added `du_pep517: maturin` to support PEP 517 builds. Updated the version to 43.0.3, ensuring compatibility with the latest dependencies.

(cherry picked from commit 9641cb83be499146ace8b6b759523d4bd1c08963) (cherry picked from commit d60922ad0ae07469c7d2a54eab64af58cb3c8ed3)