### PR TITLE
[python-modules-kit] add `importlib_metadata` to deps for `setuptools_scm`

### DIFF
--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -225,10 +225,12 @@ setuptools_standalone_pythons:
 
         pydeps:
           py:all:
+            - importlib_metadata
             - packaging
             - setuptools
             - tomli
           py:all:build:
+            - importlib_metadata
             - setuptools
           use:test:
             - build


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#355