### PR TITLE
Add needed packages from `mark-unstable` to `mark-xl`

### DIFF
--- a/core-hw-kit/merge.kit.d/base.yml
+++ b/core-hw-kit/merge.kit.d/base.yml
@@ -30,10 +30,13 @@ target:
 
     - pkg: sys-apps/hwloc
     - pkg: sys-apps/lm_sensors
+    - pkg: sys-apps/lshw
+    - pkg: sys-apps/smartmontools
 
     - pkg: sys-firmware/edk2-ovmf-bin
     - pkg: sys-firmware/edk2-ovmf
     - pkg: sys-firmware/ipxe
+    - pkg: sys-firmware/intel-microcode
     - pkg: sys-firmware/sgabios
     - pkg: sys-firmware/seabios
     - pkg: sys-firmware/seabios-bin

--- a/core-server-kit/merge.kit.d/fs.yml
+++ b/core-server-kit/merge.kit.d/fs.yml
@@ -23,6 +23,7 @@ target:
   atoms:
     - pkg: sys-block/thin-provisioning-tools
 
+    - pkg: sys-fs/autofs
     - pkg: sys-fs/btrfs-progs
     - pkg: sys-fs/cryptsetup
 
@@ -44,6 +45,7 @@ target:
     - pkg: sys-fs/growpart
     - pkg: sys-fs/reiser4progs
     - pkg: sys-fs/reiserfsprogs
+    - pkg: sys-fs/sysfsutils
     - pkg: sys-fs/mdadm
     - pkg: sys-fs/mtools
     - pkg: sys-fs/multipath-tools

--- a/core-server-kit/merge.kit.d/telemetry_from_unstable.yml
+++ b/core-server-kit/merge.kit.d/telemetry_from_unstable.yml
@@ -2,7 +2,7 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-xl"
 
 - name: "core-server-kit"
   url: "https://github.com/macaroni-os/core-server-kit"

--- a/core-server-kit/merge.kit.d/tools.yml
+++ b/core-server-kit/merge.kit.d/tools.yml
@@ -32,7 +32,6 @@ target:
     max_versions: 3
 
   atoms:
-
     - pkg: app-admin/ansible
     - pkg: app-admin/ansible-base
     - pkg: app-admin/awscli
@@ -43,9 +42,11 @@ target:
     - pkg: app-admin/metalog
     - pkg: app-admin/rsyslog
     - pkg: app-admin/syslog-ng
+    - pkg: app-admin/sysstat
 
     - pkg: app-backup/backrest
     - pkg: app-backup/restic
+    - pkg: app-backup/rsnapshot
 
     - pkg: app-emulation/containerd
     - pkg: app-emulation/docker
@@ -65,11 +66,33 @@ target:
     - pkg: app-misc/rdfind
     - pkg: app-misc/screen
 
+    - pkg: app-shells/bash-completion
+
     - pkg: dev-util/jenkins-bin
     - pkg: dev-util/jenkins-lts-bin
+    
+    - pkg: sys-apps/cpuid
+    - pkg: sys-apps/dbus
+    - pkg: sys-apps/dool
+    - pkg: sys-apps/dtc
+    - pkg: sys-apps/hdparm
+    - pkg: sys-apps/hwids
+    - pkg: sys-apps/kbd
+    - pkg: sys-apps/logwatch
+    - pkg: sys-apps/lsb-release
+    - pkg: sys-apps/openrc
+    - pkg: sys-apps/pciutils
+    - pkg: sys-apps/systemd-tmpfiles
+    - pkg: sys-apps/texinfo
+    - pkg: sys-apps/usbutils
+    - pkg: sys-apps/usbredir
 
     - pkg: sys-block/parted
 
+    - pkg: sys-power/cpupower
+    - pkg: sys-power/powertop
+
+    - pkg: sys-process/at
     - pkg: sys-process/cronbase
     - pkg: sys-process/cronie
     - pkg: sys-process/criu
@@ -77,34 +100,18 @@ target:
     - pkg: sys-process/lsof
     - pkg: sys-process/htop
     - pkg: sys-process/iotop
+    - pkg: sys-process/parallel
     - pkg: sys-process/procps
     - pkg: sys-process/procs
     - pkg: sys-process/psmisc
     - pkg: sys-process/numactl
     - pkg: sys-process/tini
 
-    - pkg: sys-apps/kbd
-
-    - pkg: sys-apps/cpuid
-    - pkg: sys-apps/dtc
-    - pkg: sys-apps/hwids
-    - pkg: sys-apps/lsb-release
-    - pkg: sys-apps/openrc
-    - pkg: sys-apps/pciutils
-    - pkg: sys-apps/texinfo
-    - pkg: sys-apps/usbutils
-    - pkg: sys-apps/usbredir
-    - pkg: sys-apps/dbus
-    - pkg: sys-apps/systemd-tmpfiles
-
     - pkg: sys-devel/bc
 
     - pkg: sys-libs/gpm
     - pkg: sys-libs/libutempter
 
-    - pkg: sys-power/cpupower
-
     - pkg: virtual/cron
     - pkg: virtual/logger
     - pkg: virtual/service-manager
-

--- a/dev-kit/merge.kit.d/base.yml
+++ b/dev-kit/merge.kit.d/base.yml
@@ -66,9 +66,10 @@ target:
 
     - pkg: app-misc/asciinema
     - pkg: app-misc/jq
-    - pkg: app-misc/yq-go
     - pkg: app-misc/google-cloud-sdk
     - pkg: app-misc/neofetch
+    - pkg: app-misc/rlwrap
+    - pkg: app-misc/yq-go
 
     - pkg: app-text/asciidoc
     - pkg: app-text/manpager
@@ -121,8 +122,9 @@ target:
     - pkg: dev-libs/liblognorm
     - pkg: dev-libs/libmaxminddb
     - pkg: dev-libs/librdkafka
-    - pkg: dev-libs/libsodium
+    - pkg: dev-libs/libsecp256k1
     - pkg: dev-libs/libsigsegv
+    - pkg: dev-libs/libsodium
     - pkg: dev-libs/lzo
     - pkg: dev-libs/jsoncpp
     - pkg: dev-libs/json-c

--- a/net-kit/merge.kit.d/base.yml
+++ b/net-kit/merge.kit.d/base.yml
@@ -37,6 +37,10 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: app-admin/sshguard
+    - pkg: app-admin/ulogd
+
+    - pkg: mail-client/alpine
 
     - pkg: mail-mta/dovecot
     - pkg: mail-mta/postfix
@@ -44,14 +48,11 @@ target:
     - pkg: mail-mta/nullmailer
     - pkg: mail-mta/sendmail
 
-    - pkg: net-mail/dovecot
-    - pkg: net-mail/mailbase
-    - pkg: net-mail/fetchmail
-
     - pkg: net-analyzer/arpwatch
     - pkg: net-analyzer/hping
     - pkg: net-analyzer/macchanger
     - pkg: net-analyzer/net-snmp
+    - pkg: net-analyzer/nettop
     - pkg: net-analyzer/openbsd-netcat
     - pkg: net-analyzer/rrdtool
     - pkg: net-analyzer/fail2ban
@@ -72,24 +73,56 @@ target:
     - pkg: net-dns/coredns
     - pkg: net-dns/dnsmasq
     - pkg: net-dns/dnssec-root
-    - pkg: net-dns/openresolv
     - pkg: net-dns/libidn
-
-    - pkg: net-nds/openldap
+    - pkg: net-dns/openresolv
 
     - pkg: net-firewall/conntrack-tools
     - pkg: net-firewall/ebtables
+    - pkg: net-firewall/ipset
     - pkg: net-firewall/iptables
     - pkg: net-firewall/nftables
-    - pkg: net-firewall/ipset
+    - pkg: net-firewall/shorewall
 
     - pkg: net-fs/libnfs
     - pkg: net-fs/minio
     - pkg: net-fs/minio-client
+    - pkg: net-fs/nfs-utils
 
     - pkg: net-ftp/atftp
     - pkg: net-ftp/ftpbase
     - pkg: net-ftp/proftpd
+
+    - pkg: net-libs/libasyncns
+    - pkg: net-libs/libesmtp
+    - pkg: net-libs/libiscsi
+    - pkg: net-libs/libmnl
+    - pkg: net-libs/libndp
+    - pkg: net-libs/libnet
+    - pkg: net-libs/libnetfilter_acct
+    - pkg: net-libs/libnetfilter_conntrack
+    - pkg: net-libs/libnetfilter_cthelper
+    - pkg: net-libs/libnetfilter_cttimeout
+    - pkg: net-libs/libnetfilter_log
+    - pkg: net-libs/libnetfilter_queue
+    - pkg: net-libs/libnfnetlink
+    - pkg: net-libs/libnftnl
+    - pkg: net-libs/libnsl
+    - pkg: net-libs/libpcap
+    - pkg: net-libs/libpcapnav
+    - pkg: net-libs/libslirp
+    - pkg: net-libs/libssh
+    - pkg: net-libs/libssh2
+    - pkg: net-libs/libtirpc
+    - pkg: net-libs/libtorrent
+    - pkg: net-libs/rpcsvc-proto
+    - pkg: net-libs/zeromq
+
+    - pkg: net-mail/dovecot
+    - pkg: net-mail/mailbase
+    - pkg: net-mail/fetchmail
+    - pkg: net-mail/getmail
+    - pkg: net-mail/mailutils
+    - pkg: net-mail/mailx
 
     - pkg: net-misc/bridge-utils
     - pkg: net-misc/dhcpcd
@@ -99,6 +132,7 @@ target:
     - pkg: net-misc/iputils
     - pkg: net-misc/iperf:3
     - pkg: net-misc/ipcalc
+    - pkg: net-misc/keychain
     - pkg: net-misc/networkmanager
     - pkg: net-misc/lksctp-tools
     - pkg: net-misc/rsync
@@ -112,59 +146,44 @@ target:
     - pkg: net-misc/socat
     - pkg: net-misc/sshpass
     - pkg: net-misc/stunnel
+    - pkg: net-misc/tigervnc
     - pkg: net-misc/whois
 
-    - pkg: net-wireless/crda
-    - pkg: net-wireless/iwd
-    - pkg: net-wireless/wireless-regdb
-    - pkg: net-wireless/wireless-tools
-    - pkg: net-wireless/wepattack
-    - pkg: net-wireless/wavemon
+    - pkg: net-nds/openldap
+    - pkg: net-nds/rpcbind
 
     - pkg: net-p2p/rtorrent
+    - pkg: net-p2p/syncthing
 
     - pkg: net-print/cups
     - pkg: net-print/cups-filters
 
     - pkg: net-proxy/cntlm
     - pkg: net-proxy/haproxy
+    - pkg: net-proxy/privoxy
+    - pkg: net-proxy/torsocks
 
     - pkg: net-vpn/openconnect
     - pkg: net-vpn/openfortivpn
     - pkg: net-vpn/openvpn
-    - pkg: net-vpn/wireguard-tools
     - pkg: net-vpn/tailscale
     - pkg: net-vpn/vpnc
+    - pkg: net-vpn/wireguard-tools
 
-    - pkg: net-libs/libasyncns
-    - pkg: net-libs/libesmtp
-    - pkg: net-libs/libiscsi
-    - pkg: net-libs/libnet
-    - pkg: net-libs/libnsl
-    - pkg: net-libs/libmnl
-    - pkg: net-libs/libndp
-    - pkg: net-libs/libnetfilter_conntrack
-    - pkg: net-libs/libnetfilter_cthelper
-    - pkg: net-libs/libnetfilter_cttimeout
-    - pkg: net-libs/libnetfilter_queue
-    - pkg: net-libs/libnftnl
-    - pkg: net-libs/libnfnetlink
-    - pkg: net-libs/libpcap
-    - pkg: net-libs/libpcapnav
-    - pkg: net-libs/libslirp
-    - pkg: net-libs/libssh
-    - pkg: net-libs/libssh2
-    - pkg: net-libs/libtorrent
-    - pkg: net-libs/libtirpc
-    - pkg: net-libs/rpcsvc-proto
-    - pkg: net-libs/zeromq
-
-    - pkg: www-apps/gitea
+    - pkg: net-wireless/crda
+    - pkg: net-wireless/iwd
+    - pkg: net-wireless/wavemon
+    - pkg: net-wireless/wepattack
+    - pkg: net-wireless/wireless-regdb
+    - pkg: net-wireless/wireless-tools
 
     - pkg: sys-apps/iproute2
     - pkg: sys-apps/net-tools
     - pkg: sys-apps/ethtool
     - pkg: sys-apps/tcp-wrappers
 
+    - pkg: www-apps/gitea
+
+    - pkg: virtual/mailx
     - pkg: virtual/mta
     - pkg: virtual/resolvconf

--- a/net-kit/merge.kit.d/www-client.yml
+++ b/net-kit/merge.kit.d/www-client.yml
@@ -26,5 +26,6 @@ target:
 
   atoms:
 
+    - pkg: www-client/elinks
     - pkg: www-client/lynx
     - pkg: www-client/w3m

--- a/perl-kit/merge.kit.d/perl.yml
+++ b/perl-kit/merge.kit.d/perl.yml
@@ -35,9 +35,12 @@ target:
     - pkg: dev-perl/Class-Data-Inheritable
     - pkg: dev-perl/Crypt-PasswdMD5
     - pkg: dev-perl/Crypt-RC4
+    - pkg: dev-perl/Date-Calc
+    - pkg: dev-perl/Date-Manip
     - pkg: dev-perl/Devel-Caller
     - pkg: dev-perl/Devel-GlobalDestruction
     - pkg: dev-perl/Devel-LexAlias
+    - pkg: dev-perl/Devel-Size
     - pkg: dev-perl/Digest-Perl-MD5
     - pkg: dev-perl/Digest-SHA1
     - pkg: dev-perl/Digest-HMAC
@@ -45,16 +48,22 @@ target:
     - pkg: dev-perl/File-BaseDir
     - pkg: dev-perl/File-DesktopEntry
     - pkg: dev-perl/File-MimeInfo
+    - pkg: dev-perl/HTML/Parser
+    - pkg: dev-perl/IO-Socket-SSL
     - pkg: dev-perl/IO-stringy
     - pkg: dev-perl/IPC-System-Simple
     - pkg: dev-perl/JSON
     - pkg: dev-perl/JSON-XS
+    - pkg: dev-perl/Lchown
     - pkg: dev-perl/Locale-gettext
     - pkg: dev-perl/Log-Dispatch
+    - pkg: dev-perl/MailTools
+    - pkg: dev-perl/MIME-Charset
     - pkg: dev-perl/Module-Build
     - pkg: dev-perl/Module-Implementation
     - pkg: dev-perl/Module-Runtime
     - pkg: dev-perl/MRO-Compat
+    - pkg: dev-perl/Net-SSLeay
     - pkg: dev-perl/OLE-StorageLite
     - pkg: dev-perl/Package-Stash-XS
     - pkg: dev-perl/PadWalker
@@ -62,25 +71,19 @@ target:
     - pkg: dev-perl/Pod-Parser
     - pkg: dev-perl/Ref-Util-XS
     - pkg: dev-perl/Role-Tiny
-    - pkg: dev-perl/XML-LibXML
-    - pkg: dev-perl/XML-NamespaceSupport
-    - pkg: dev-perl/XML-Parser
-    - pkg: dev-perl/XML-SAX
-    - pkg: dev-perl/XML-SAX-Base
-
-    - pkg: dev-perl/IO-Socket-SSL
-    - pkg: dev-perl/MIME-Charset
-    - pkg: dev-perl/MailTools
-    - pkg: dev-perl/Net-SSLeay
     - pkg: dev-perl/SGMLSpm
+    - pkg: dev-perl/Socket6
     - pkg: dev-perl/Sub-Exporter
     - pkg: dev-perl/Sub-Exporter-Progressive
     - pkg: dev-perl/Sub-Identify
     - pkg: dev-perl/Sub-Install
+    - pkg: dev-perl/Sys-CPU
+    - pkg: dev-perl/Sys-MemInfo
     - pkg: dev-perl/TermReadKey
     - pkg: dev-perl/Text-CharWidth
     - pkg: dev-perl/Text-Unidecode
     - pkg: dev-perl/Text-WrapI18N
+    - pkg: dev-perl/Tie-IxHash
     - pkg: dev-perl/Types-Serialiser
     - pkg: dev-perl/Try-Tiny
     - pkg: dev-perl/TimeDate
@@ -88,6 +91,11 @@ target:
     - pkg: dev-perl/Unicode-LineBreak
     - pkg: dev-perl/Unicode-Map
     - pkg: dev-perl/URI
+    - pkg: dev-perl/XML-LibXML
+    - pkg: dev-perl/XML-NamespaceSupport
+    - pkg: dev-perl/XML-Parser
+    - pkg: dev-perl/XML-SAX
+    - pkg: dev-perl/XML-SAX-Base
     - pkg: dev-perl/XML-XPath
     - pkg: dev-perl/YAML-Tiny
     - pkg: dev-perl/libintl-perl

--- a/portage-kit/merge.kit.d/portage.yml
+++ b/portage-kit/merge.kit.d/portage.yml
@@ -69,6 +69,8 @@ target:
     - pkg: app-portage/gentoolkit
     - pkg: app-portage/portage-utils
 
+    - pkg: app-shells/gentoo-bashcomp
+
     - pkg: sys-apps/elfix
     - pkg: sys-apps/gentoo-functions
     - pkg: sys-apps/install-xattr

--- a/security-kit/merge.kit.d/security.yml
+++ b/security-kit/merge.kit.d/security.yml
@@ -40,6 +40,8 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: app-admin/pwgen
+
     - pkg: app-crypt/argon2
     - pkg: app-crypt/gpgme:1
     - pkg: app-crypt/gnupg

--- a/text-kit/merge.kit.d/common.yml
+++ b/text-kit/merge.kit.d/common.yml
@@ -22,11 +22,6 @@ target:
 
   atoms:
 
-    - pkg: app-i18n/unicode-emoji
-
-    - pkg: app-doc/xmltoman
-    - pkg: app-doc/doxygen
-
     - pkg: app-dicts/aspell-en
     - pkg: app-dicts/aspell-sl
     - pkg: app-dicts/aspell-no
@@ -64,9 +59,15 @@ target:
     - pkg: app-dicts/aspell-fo
     - pkg: app-dicts/aspell-fr
 
+    - pkg: app-doc/xmltoman
+    - pkg: app-doc/doxygen
+
+    - pkg: app-i18n/unicode-emoji
+
     - pkg: app-text/asciidoctor
     - pkg: app-text/aspell
     - pkg: app-text/discount
+    - pkg: app-text/dos2unix
     - pkg: app-text/dvipsk
     - pkg: app-text/xmlto
     - pkg: app-text/ghostscript-gpl

--- a/xorg-kit/merge.kit.d/base.yml
+++ b/xorg-kit/merge.kit.d/base.yml
@@ -66,6 +66,7 @@ target:
     - pkg: x11-base/xorg-proto
 
     - pkg: x11-libs/cairo
+    - pkg: x11-libs/fltk
     - pkg: x11-libs/libX11
     - pkg: x11-libs/libXau
     - pkg: x11-libs/libXdmcp


### PR DESCRIPTION
Essentially mirrors the PR for `mark-unstable` here: https://github.com/macaroni-os/kit-fixups/pull/338