### PR TITLE
[mark-xl] Add `x11-proto/xwaylandproto` to `xorg-kit`

### DIFF
--- a/xorg-kit/merge.kit.d/base.yml
+++ b/xorg-kit/merge.kit.d/base.yml
@@ -105,6 +105,7 @@ target:
     - pkg: x11-proto/dri2proto
     - pkg: x11-proto/glproto
     - pkg: x11-proto/xproto
+    - pkg: x11-proto/xwaylandproto
 
     - pkg: virtual/ttf-fonts
 


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#367