### PR TITLE
[core-kit/portage-kit] add correct `PORTDIR_CACHE_METHOD directive` to `/etc/eixrc/...`

### DIFF
--- a/core-kit/curated/app-portage/eix/templates/eix.tmpl
+++ b/core-kit/curated/app-portage/eix/templates/eix.tmpl
@@ -86,6 +86,7 @@ src_install() {
 	default
 	dobashcomp bash/eix
 	dotmpfiles tmpfiles.d/eix.conf
+	echo 'PORTDIR_CACHE_METHOD="parse#metadata-md5#metadata-flat#assign"' >> "${D}"/etc/eixrc/mark.conf
 
 	rm -r "${ED}"/usr/bin/eix-functions.sh || die
 }
@@ -104,3 +105,5 @@ pkg_postrm() {
 		rm -rf "${EROOT}/var/cache/${PN}" || die
 	fi
 }
+
+# vim: syn=ebuild


### PR DESCRIPTION
We need to add 
```
PORTDIR_CACHE_METHOD="parse#metadata-md5#metadata-flat#assign"
```
to the default `eixrc` in order for `eix` to work properly with `core-kit` (and more?) in `mark-xl`.

Here's a trivial patch to add the necessary line in the right place.