### PR TITLE
[core-kit] sys-apps/screen Fix build script to reference correct docu…

### DIFF
--- a/core-kit/mark/sys-apps/templates/screen.tmpl
+++ b/core-kit/mark/sys-apps/templates/screen.tmpl
@@ -88,7 +88,7 @@ src_configure() {
 src_compile() {
 	LC_ALL=POSIX emake comm.h term.h
 
-	emake -C doc screen.info
+	emake -C doc screen.texinfo
 	default
 }
 


### PR DESCRIPTION
…mentation file

Updated the build process to use 'screen.texinfo' instead of 'screen.info' in the 'emake' command. This ensures compatibility with the current documentation format and resolves build issues.

(cherry picked from commit ccc9fbb7322340f781ae73d42b44a0705bde3cbc) (cherry picked from commit 1c11ff582c262a36991c2be4ca888562e1dc72f0)