### PR TITLE
[python-modules-kit] dev-python/zipp Update autogen.yaml to adjust sr…

### DIFF
--- a/python-modules-kit/mark/dev-python/autogen.yaml
+++ b/python-modules-kit/mark/dev-python/autogen.yaml
@@ -107,6 +107,11 @@ autogens:
           py:all:
             - toml
             - setuptools_scm
+        body: |
+          src_prepare() {
+            sed -i -e 's/license = "MIT"/license = { text = "MIT" }/' pyproject.toml || die
+            distutils-r1_src_prepare
+          }
     - ujson
     - ufbt:
         license: GPL-3+


### PR DESCRIPTION
…c_prepare for license format

Added a custom `src_prepare` to modify the license field in `pyproject.toml`, ensuring compatibility with the package building process. This change updates the license definition to adhere to the required formatting.

(cherry picked from commit a3a34c98524d05b1668489c23e109b79d44d14ea) (cherry picked from commit bcb6a86da6cdc9b6f3032c0a82f2d77d5d270662)