### PR TITLE
[python-modules-kit] dev-python/configargparse Remove redundant pypi_…

### DIFF
--- a/python-modules-kit/curated/dev-python/autogen.yaml
+++ b/python-modules-kit/curated/dev-python/autogen.yaml
@@ -394,7 +394,6 @@ dev_python_compat_rule:
           5.0.0: 1
     - configargparse:
         blocker: '!<dev-python/configargparse-1.7.0'
-        pypi_name: ConfigArgParse
     - docutils:
         du_pep517: generator
         blocker: '!<dev-python/docutils-0.19-r1'


### PR DESCRIPTION
…name field from autogen.yaml

(cherry picked from commit 550a86f89608955df8ac3ef230e6f7b9f3141300) (cherry picked from commit 2fb3eed5d65ffe338a3122bbda3002ea6d454f61)