### PR TITLE
[core-server-kit] sys-libs/liburing Add patch for version 2.10 and up…

### DIFF
--- a/core-server-kit/curated/sys-libs/liburing/autogen.yaml
+++ b/core-server-kit/curated/sys-libs/liburing/autogen.yaml
@@ -6,4 +6,5 @@ liburing:
           user: axboe
           repo: liburing
           query: releases
-
+        revision:
+          '2.10': '1'

--- a/core-server-kit/curated/sys-libs/liburing/files/liburing-2.10-io_uring_cqe_iter_cqhead.patch
+++ b/core-server-kit/curated/sys-libs/liburing/files/liburing-2.10-io_uring_cqe_iter_cqhead.patch
@@ -1,0 +1,62 @@
+From 6836160ae6ae9fdc20d703de55162bfc97169542 Mon Sep 17 00:00:00 2001
+From: Florian Schmaus <flo@geekplace.eu>
+Date: Mon, 2 Jun 2025 15:00:55 +0200
+Subject: [PATCH] Fix potential compilation error due to io_uring_for_each_cqe
+ macro
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In 1c1c806ff4e1 ("Add struct io_uring_cqe_iter") the body of the
+io_uring_for_each_cqe macro was changed to use io_uring_cqe_iter and
+its 'head' member. However, the '.head' use site in the macro's body
+clashes with the macro's 'head' argument. This leads to compilation
+errors if the macro is invoked with something else as 'head' as second
+argument.
+
+For example, Samba uses the macro as follows:
+
+io_uring_for_each_cqe(&config->uring, cqhead, cqe) {
+   …
+}
+
+which results in
+
+In file included from ../../source3/modules/vfs_io_uring.c:49:
+../../source3/modules/vfs_io_uring.c: In function ‘_vfs_io_uring_queue_run’:
+../../source3/modules/vfs_io_uring.c:297:47: error: ‘struct io_uring_cqe_iter’ has no member named ‘cqhead’; did you mean ‘head’?
+  297 |         io_uring_for_each_cqe(&config->uring, cqhead, cqe) {
+
+as reported in https://bugs.gentoo.org/956879
+
+Fixes: 1c1c806ff4e1d2a122180612d5d75cf648a33211
+Signed-off-by: Florian Schmaus <flo@geekplace.eu>
+---
+ src/include/liburing.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/include/liburing.h b/src/include/liburing.h
+index abaf75dde..487b1ccbe 100644
+--- a/src/include/liburing.h
++++ b/src/include/liburing.h
+@@ -379,15 +379,15 @@ IOURINGINLINE bool io_uring_cqe_iter_next(struct io_uring_cqe_iter *iter,
+ }
+
+ /*
+- * NOTE: we should just get rid of the 'head' being passed in here, it doesn't
++ * NOTE: we should just get rid of the '__head__' being passed in here, it doesn't
+  * serve a purpose anymore. The below is a bit of a work-around to ensure that
+- * the compiler doesn't complain about 'head' being unused (or only written,
++ * the compiler doesn't complain about '__head__' being unused (or only written,
+  * never read), as we use a local iterator for both the head and tail tracking.
+  */
+-#define io_uring_for_each_cqe(ring, head, cqe)					\
++#define io_uring_for_each_cqe(ring, __head__, cqe)					\
+ 	for (struct io_uring_cqe_iter __ITER__ = io_uring_cqe_iter_init(ring);	\
+-	     (head) = __ITER__.head, io_uring_cqe_iter_next(&__ITER__, &(cqe));	\
+-	     (void)(head))
++	     (__head__) = __ITER__.head, io_uring_cqe_iter_next(&__ITER__, &(cqe));	\
++	     (void)(__head__))
+
+ /*
+  * Must be called after io_uring_for_each_cqe()

--- a/core-server-kit/curated/sys-libs/liburing/templates/liburing.tmpl
+++ b/core-server-kit/curated/sys-libs/liburing/templates/liburing.tmpl
@@ -21,6 +21,7 @@ RDEPEND="${DEPEND}"
 PATCHES=(
 	# https://bugs.gentoo.org/891633
 	"${FILESDIR}/${PN}-2.3-liburing.map-Export-io_uring_-enable_rings-register_.patch"
+	"${FILESDIR}/${PN}-2.10-io_uring_cqe_iter_cqhead.patch"
 )
 
 post_src_unpack() {


### PR DESCRIPTION
…date autogen.yaml

Introduced `liburing-2.10-io_uring_cqe_iter_cqhead.patch` to address missing exports in liburing 2.10. Updated autogen.yaml with the new revision.

(cherry picked from commit 2fb55387459e6ff1d3d831b4feeb5473ec36cedb)