### PR TITLE
[mark-xl] Rebase from `mark-testing` -> `mark-unstable`

### DIFF
--- a/core-hw-kit/merge.kit.d/base.yml
+++ b/core-hw-kit/merge.kit.d/base.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "core-hw-kit"
   url: "https://github.com/macaroni-os/core-hw-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: core-hw-kit

--- a/core-kit/merge.kit.d/core.yml
+++ b/core-kit/merge.kit.d/core.yml
@@ -1,32 +1,8 @@
 sources:
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
   #commit_sha1: "1456ea54c3efae418e8de419af2ea1b66ab2cbaa"
-
-- name: "core-server-kit"
-  url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
-
-- name: "core-hw-kit"
-  url: "https://github.com/macaroni-os/core-hw-kit"
-  branch: "mark-testing"
-
-- name: "perl-kit"
-  url: "https://github.com/macaroni-os/perl-kit"
-  branch: "mark-testing"
-
-- name: "python-kit"
-  url: "https://github.com/macaroni-os/python-kit"
-  branch: "mark-testing"
-
-- name: "python-modules-kit"
-  url: "https://github.com/macaroni-os/python-modules-kit"
-  branch: "mark-testing"
-
-- name: "security-kit"
-  url: "https://github.com/macaroni-os/security-kit"
-  branch: "mark-testing"
 
 target:
   name: core-kit

--- a/core-server-kit/merge.kit.d/db.yml
+++ b/core-server-kit/merge.kit.d/db.yml
@@ -2,15 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "core-server-kit"
   url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
-
-- name: "dev-kit"
-  url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: core-server-kit

--- a/core-server-kit/merge.kit.d/fs.yml
+++ b/core-server-kit/merge.kit.d/fs.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "core-server-kit"
   url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"

--- a/core-server-kit/merge.kit.d/libs.yml
+++ b/core-server-kit/merge.kit.d/libs.yml
@@ -2,19 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "core-server-kit"
   url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
-
-- name: "dev-kit"
-  url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
-
-- name: "security-kit"
-  url: "https://github.com/macaroni-os/security-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: core-server-kit

--- a/core-server-kit/merge.kit.d/net-base.yml
+++ b/core-server-kit/merge.kit.d/net-base.yml
@@ -2,23 +2,15 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "core-server-kit"
   url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"
   branch: "funtoo"
-
-- name: "net-kit"
-  url: "https://github.com/macaroni-os/net-kit"
-  branch: "mark-testing"
-
-- name: "python-modules-kit"
-  url: "https://github.com/macaroni-os/python-modules-kit"
-  branch: "mark-testing"
 
 target:
   name: core-server-kit

--- a/core-server-kit/merge.kit.d/telemetry.yml
+++ b/core-server-kit/merge.kit.d/telemetry.yml
@@ -2,15 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "core-server-kit"
   url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
-
-- name: "net-kit"
-  url: "https://github.com/macaroni-os/net-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"

--- a/core-server-kit/merge.kit.d/tools.yml
+++ b/core-server-kit/merge.kit.d/tools.yml
@@ -2,19 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "core-server-kit"
   url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
-
-- name: "net-kit"
-  url: "https://github.com/macaroni-os/net-kit"
-  branch: "mark-testing"
-
-- name: "core-hw-kit"
-  url: "https://github.com/macaroni-os/core-hw-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"

--- a/dev-kit/merge.kit.d/base.yml
+++ b/dev-kit/merge.kit.d/base.yml
@@ -2,43 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
-
-- name: "core-server-kit"
-  url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
-
-- name: "core-gl-kit"
-  url: "https://github.com/macaroni-os/core-gl-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "dev-kit"
   url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
-
-- name: "lang-kit"
-  url: "https://github.com/macaroni-os/lang-kit"
-  branch: "mark-testing"
-
-- name: "text-kit"
-  url: "https://github.com/macaroni-os/text-kit"
-  branch: "mark-testing"
-
-- name: "security-kit"
-  url: "https://github.com/macaroni-os/security-kit"
-  branch: "mark-testing"
-
-- name: "gnome-kit"
-  url: "https://github.com/macaroni-os/gnome-kit"
-  branch: "mark-testing"
-
-- name: "media-kit"
-  url: "https://github.com/macaroni-os/media-kit"
-  branch: "mark-testing"
-
-- name: "python-modules-kit"
-  url: "https://github.com/macaroni-os/python-modules-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: dev-kit

--- a/editors-kit/merge.kit.d/editors.yml
+++ b/editors-kit/merge.kit.d/editors.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "editors-kit"
   url: "https://github.com/macaroni-os/editors-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: editors-kit

--- a/java-kit/merge.kit.d/base.yml
+++ b/java-kit/merge.kit.d/base.yml
@@ -4,13 +4,9 @@ sources:
   url: "https://github.com/macaroni-os/core-kit"
   branch: "mark-xl"
 
-- name: "dev-kit"
-  url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
-
 - name: "java-kit"
   url: "https://github.com/macaroni-os/java-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: java-kit

--- a/kernel-kit/merge.kit.d/base.yml
+++ b/kernel-kit/merge.kit.d/base.yml
@@ -2,15 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
-- name: "core-hw-kit"
-  url: "https://github.com/macaroni-os/core-hw-kit"
-  branch: "mark-testing"
-
-- name: "security-kit"
-  url: "https://github.com/macaroni-os/security-kit"
-  branch: "mark-testing"
+- name: "kernel-kit"
+  url: "https://github.com/macaroni-os/kernel-kit"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"

--- a/kernel-kit/merge.kit.d/debian.yml
+++ b/kernel-kit/merge.kit.d/debian.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
-- name: "security-kit"
-  url: "https://github.com/macaroni-os/security-kit"
-  branch: "mark-testing"
+- name: "kernel-kit"
+  url: "https://github.com/macaroni-os/kernel-kit"
+  branch: "mark-unstable"
 
 target:
   name: kernel-kit

--- a/kernel-kit/merge.kit.d/modules.yml
+++ b/kernel-kit/merge.kit.d/modules.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
-- name: "security-kit"
-  url: "https://github.com/macaroni-os/security-kit"
-  branch: "mark-testing"
+- name: "kernel-kit"
+  url: "https://github.com/macaroni-os/kernel-kit"
+  branch: "mark-unstable"
 
 target:
   name: kernel-kit

--- a/lang-kit/merge.kit.d/base.yml
+++ b/lang-kit/merge.kit.d/base.yml
@@ -2,23 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
-
-- name: "core-server-kit"
-  url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "lang-kit"
   url: "https://github.com/macaroni-os/lang-kit"
-  branch: "mark-testing"
-
-- name: "security-kit"
-  url: "https://github.com/macaroni-os/security-kit"
-  branch: "mark-testing"
-
-- name: "lisp-scheme-kit"
-  url: "https://github.com/macaroni-os/lisp-scheme-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"

--- a/lisp-scheme-kit/merge.kit.d/base.yml
+++ b/lisp-scheme-kit/merge.kit.d/base.yml
@@ -6,7 +6,7 @@ sources:
 
 - name: "lisp-scheme-kit"
   url: "https://github.com/macaroni-os/lisp-scheme-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: lisp-scheme-kit

--- a/llvm-kit/merge.kit.d/base.yml
+++ b/llvm-kit/merge.kit.d/base.yml
@@ -2,7 +2,7 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "llvm-kit"
   url: "https://github.com/macaroni-os/llvm-kit"

--- a/net-kit/merge.kit.d/base.yml
+++ b/net-kit/merge.kit.d/base.yml
@@ -2,31 +2,15 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
-
-- name: "core-server-kit"
-  url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "net-kit"
   url: "https://github.com/macaroni-os/net-kit"
-  branch: "mark-testing"
-
-- name: "desktop-kit"
-  url: "https://github.com/macaroni-os/desktop-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"
   branch: "funtoo"
-
-- name: "core-hw-kit"
-  url: "https://github.com/macaroni-os/core-hw-kit"
-  branch: "mark-testing"
-
-- name: "python-modules-kit"
-  url: "https://github.com/macaroni-os/python-modules-kit"
-  branch: "mark-testing"
 
 target:
   name: net-kit

--- a/net-kit/merge.kit.d/www-client.yml
+++ b/net-kit/merge.kit.d/www-client.yml
@@ -2,19 +2,15 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
-
-- name: "core-server-kit"
-  url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "net-kit"
   url: "https://github.com/macaroni-os/net-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "browser-kit"
   url: "https://github.com/macaroni-os/browser-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: net-kit

--- a/perl-kit/merge.kit.d/perl.yml
+++ b/perl-kit/merge.kit.d/perl.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "perl-kit"
   url: "https://github.com/macaroni-os/perl-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: perl-kit

--- a/php-kit/merge.kit.d/base.yml
+++ b/php-kit/merge.kit.d/base.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
-- name: "core-server-kit"
-  url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
+- name: "php-kit"
+  url: "https://github.com/macaroni-os/php-kit"
+  branch: "mark-unstable"
 
 target:
   name: php-kit

--- a/portage-kit/merge.kit.d/funtoo.yml
+++ b/portage-kit/merge.kit.d/funtoo.yml
@@ -2,7 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
+
+- name: "portage-kit"
+  url: "https://github.com/macaroni-os/portage-kit"
+  branch: "mark-unstable"
 
 target:
   name: portage-kit

--- a/portage-kit/merge.kit.d/portage.yml
+++ b/portage-kit/merge.kit.d/portage.yml
@@ -2,27 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
-- name: "ruby-kit"
-  url: "https://github.com/macaroni-os/ruby-kit"
-  branch: "mark-testing"
-
-- name: "perl-kit"
-  url: "https://github.com/macaroni-os/perl-kit"
-  branch: "mark-testing"
-
-- name: "core-server-kit"
-  url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
-
-- name: "dev-kit"
-  url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
-
-- name: "editors-kit"
-  url: "https://github.com/macaroni-os/editors-kit"
-  branch: "mark-testing"
+- name: "portage-kit"
+  url: "https://github.com/macaroni-os/portage-kit"
+  branch: "mark-unstable"
 
 target:
   name: portage-kit

--- a/python-kit/merge.kit.d/python.yml
+++ b/python-kit/merge.kit.d/python.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "python-kit"
   url: "https://github.com/macaroni-os/python-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: python-kit

--- a/python-modules-kit/merge.kit.d/base.yml
+++ b/python-modules-kit/merge.kit.d/base.yml
@@ -2,19 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
-
-- name: "python-kit"
-  url: "https://github.com/macaroni-os/python-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "python-modules-kit"
   url: "https://github.com/macaroni-os/python-modules-kit"
-  branch: "mark-testing"
-
-- name: "dev-kit"
-  url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"

--- a/python-modules-kit/merge.kit.d/python.yml
+++ b/python-modules-kit/merge.kit.d/python.yml
@@ -2,23 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
-
-- name: "python-kit"
-  url: "https://github.com/macaroni-os/python-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "python-modules-kit"
   url: "https://github.com/macaroni-os/python-modules-kit"
-  branch: "mark-testing"
-
-- name: "dev-kit"
-  url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
-
-- name: "core-server-kit"
-  url: "https://github.com/macaroni-os/core-server-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"

--- a/python-modules-kit/merge.kit.d/python_autogen.yml
+++ b/python-modules-kit/merge.kit.d/python_autogen.yml
@@ -4,10 +4,6 @@ sources:
   url: "https://github.com/macaroni-os/core-kit"
   branch: "mark-xl"
 
-- name: "python-kit"
-  url: "https://github.com/macaroni-os/python-kit"
-  branch: "mark-xl"
-
 - name: "python-modules-kit"
   url: "https://github.com/macaroni-os/python-modules-kit"
   branch: "mark-unstable"

--- a/ruby-kit/merge.kit.d/base.yml
+++ b/ruby-kit/merge.kit.d/base.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "ruby-kit"
   url: "https://github.com/macaroni-os/ruby-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: ruby-kit

--- a/science-kit/merge.kit.d/base.yml
+++ b/science-kit/merge.kit.d/base.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "science-kit"
   url: "https://github.com/macaroni-os/science-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: science-kit

--- a/text-kit/merge.kit.d/common.yml
+++ b/text-kit/merge.kit.d/common.yml
@@ -2,15 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "text-kit"
   url: "https://github.com/macaroni-os/text-kit"
-  branch: "mark-testing"
-
-- name: "gnome-kit"
-  url: "https://github.com/macaroni-os/gnome-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: text-kit

--- a/text-kit/merge.kit.d/docbook.yml
+++ b/text-kit/merge.kit.d/docbook.yml
@@ -2,11 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "text-kit"
   url: "https://github.com/macaroni-os/text-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: text-kit

--- a/text-kit/merge.kit.d/latex.yml
+++ b/text-kit/merge.kit.d/latex.yml
@@ -2,15 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "text-kit"
   url: "https://github.com/macaroni-os/text-kit"
-  branch: "mark-testing"
-
-- name: "gnome-kit"
-  url: "https://github.com/macaroni-os/gnome-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: text-kit

--- a/xorg-kit/merge.kit.d/base.yml
+++ b/xorg-kit/merge.kit.d/base.yml
@@ -2,19 +2,19 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "dev-kit"
   url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "gnome-kit"
   url: "https://github.com/macaroni-os/gnome-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "desktop-kit"
   url: "https://github.com/macaroni-os/desktop-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "geaaru-kit"
   url: "https://github.com/geaaru/geaaru_overlay"
@@ -22,11 +22,11 @@ sources:
 
 - name: "media-kit"
   url: "https://github.com/macaroni-os/media-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "core-gl-kit"
   url: "https://github.com/macaroni-os/core-gl-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 
 target:

--- a/xorg-kit/merge.kit.d/gnome.yml
+++ b/xorg-kit/merge.kit.d/gnome.yml
@@ -2,19 +2,11 @@ sources:
 # We need this to inherit the eclass used for kit cache JSON generation
 - name: "core-kit"
   url: "https://github.com/macaroni-os/core-kit"
-  branch: "mark-testing"
-
-- name: "dev-kit"
-  url: "https://github.com/macaroni-os/dev-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 - name: "gnome-kit"
   url: "https://github.com/macaroni-os/gnome-kit"
-  branch: "mark-testing"
-
-- name: "desktop-kit"
-  url: "https://github.com/macaroni-os/desktop-kit"
-  branch: "mark-testing"
+  branch: "mark-unstable"
 
 target:
   name: xorg-kit


### PR DESCRIPTION
We've been pulling packages directly from `mark-testing` into `mark-xl`.  We should not do that, and instead pull from `mark-unstable`.  This PR breaks the direct link between `mark-xl` and `mark-testing`.