### PR TITLE
[net-kit] Add mail-client/alpine-2.26 autogen

### DIFF
--- a/net-kit/autogen.kit.d/base.yml
+++ b/net-kit/autogen.kit.d/base.yml
@@ -315,6 +315,85 @@ flatpak:
             }
 
 
+alpine:
+  generator: builtin-noop
+  template:
+    engine: helm
+
+  defaults:
+    category: mail-client
+    files_dir: "{{ .Values.pn }}"
+
+  packages:
+    - alpine:
+        template: ../../templates/simple.tmpl
+        assets:
+          - name: "{{ .Values.pn }}-{{ .Values.version }}.tar.xz"
+            url: "https://alpineapp.email/alpine/patches/alpine-{{ .Values.version }}/alpine-{{ .Values.version }}.tar.xz"
+        transform:
+          - kind: string
+            match: 'alpine-'
+            replace: ''
+          - kind: string
+            match: '.tar.xz'
+            replace: ''
+        vars:
+          homepage: https://alpineapp.email/alpine/index.html
+          desc: An easy to use text-based based mail and news client
+          license: Apache-2.0
+          iuse: ipv6 kerberos ldap passfile nls smime ssl
+          inherit:
+            - autotools
+            - toolchain-funcs
+          rdepend: |
+            app-misc/mime-types
+            sys-libs/ncurses
+            virtual/libcrypt
+            kerberos? ( app-crypt/mit-krb5 )
+            ldap? ( net-nds/openldap )
+            ssl? ( dev-libs/openssl )
+          depend: ${RDEPEND}
+          body: |
+            src_configure() {
+              myconf=(
+                --without-tcl
+                --with-pthread
+                --with-system-pinerc="${EPREFIX}"/etc/pine.conf
+                --with-system-fixed-pinerc="${EPREFIX}"/etc/pine.conf.fixed
+                $(use_with ldap)
+                $(use_with ssl)
+                $(use_with passfile passfile .pinepwd)
+                $(use_with kerberos krb5)
+                $(use_enable nls)
+                $(use_with ipv6)
+                $(use_with smime)
+              )
+
+              if has_version "app-text/hunspell"; then
+                myconf+=( --with-interactive-spellcheck=/usr/bin/hunspell )
+              elif has_version "app-text/aspell"; then
+                myconf+=( --with-interactive-spellcheck=/usr/bin/aspell )
+              fi
+
+              if use ssl; then
+                myconf+=(
+                  --with-ssl-include-dir="${EPREFIX}"/usr/include/openssl
+                  --with-ssl-lib-dir="${EPREFIX}"/usr/$(get_libdir)
+                  --with-ssl-certs-dir="${EPREFIX}"/etc/ssl/certs
+                )
+              fi
 
 
+              # Gentoo Bug 935343; see imap/docs/bugs.txt
+              if use ipv6; then
+                sed -i "s/IP=4/IP=6/" imap/Makefile || die
+              fi
 
+              # dial down warnings about unused results
+              append-flags -Wno-unused-result
+
+              econf "${myconf[@]}"
+            }
+
+          versions:
+            - "2.26"

--- a/net-kit/merge.kit.d/base_autogen.yml
+++ b/net-kit/merge.kit.d/base_autogen.yml
@@ -13,6 +13,8 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: mail-client/alpine
+
     - pkg: net-dns/bind
     - pkg: net-dns/bind-tools
     - pkg: net-dns/unbound


### PR DESCRIPTION
I've tested the resulting ebuild locally.  It builds, and the installed files are as expected.  So far I've encountered no issues with the `alpine` binary.