### PR TITLE
[net-kit] Fix redundant `autofs` definitions

### DIFF
--- a/core-server-kit/merge.kit.d/fs.yml
+++ b/core-server-kit/merge.kit.d/fs.yml
@@ -21,9 +21,10 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: net-fs/autofs
+
     - pkg: sys-block/thin-provisioning-tools
 
-    - pkg: sys-fs/autofs
     - pkg: sys-fs/btrfs-progs
     - pkg: sys-fs/cryptsetup
 

--- a/core-server-kit/merge.kit.d/tools.yml
+++ b/core-server-kit/merge.kit.d/tools.yml
@@ -65,8 +65,6 @@ target:
     - pkg: dev-util/jenkins-bin
     - pkg: dev-util/jenkins-lts-bin
 
-    - pkg: net-fs/autofs
-
     - pkg: sys-apps/cpuid
     - pkg: sys-apps/dbus
     - pkg: sys-apps/dool


### PR DESCRIPTION
One of them had the incorrect category, so it had no effect and we didn't notice.