### PR TITLE
[mark-xl] Add intel64-{alder,rocket}lake subarches

### DIFF
--- a/core-kit/profiles/funtoo/1.0/linux-gnu/arch/x86-64bit/subarch/intel64-alderlake/make.defaults
+++ b/core-kit/profiles/funtoo/1.0/linux-gnu/arch/x86-64bit/subarch/intel64-alderlake/make.defaults
@@ -1,0 +1,6 @@
+CFLAGS="-march=alderlake -O2 -pipe"
+CXXFLAGS="${CFLAGS}"
+FFLAGS="${CFLAGS}"
+FCFLAGS="${CFLAGS}"
+
+CPU_FLAGS_X86="aes avx avx2 f16c fma3 mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 ssse3 vpclmulqdq"

--- a/core-kit/profiles/funtoo/1.0/linux-gnu/arch/x86-64bit/subarch/intel64-rocketlake/make.defaults
+++ b/core-kit/profiles/funtoo/1.0/linux-gnu/arch/x86-64bit/subarch/intel64-rocketlake/make.defaults
@@ -1,0 +1,6 @@
+CFLAGS="-march=rocketlake -O2 -pipe"
+CXXFLAGS="${CFLAGS}"
+FFLAGS="${CFLAGS}"
+FCFLAGS="${CFLAGS}"
+
+CPU_FLAGS_X86="aes avx avx2 avx512_bitalg avx512_vbmi2 avx512_vnni avx512_vpopcntdq avx512bw avx512cd avx512dq avx512f avx512ifma avx512vbmi avx512vl f16c fma3 mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 ssse3 vpclmulqdq"


### PR DESCRIPTION
These are present already in `mark-unstable` and need to be added to `mark-xl` and `mark-iii`.