### PR TITLE
[python-modules-kit] dev-python/packaging autogen

### DIFF
--- a/python-modules-kit/autogen.kit.d/python.yml
+++ b/python-modules-kit/autogen.kit.d/python.yml
@@ -83,6 +83,16 @@ flit_modules:
               fi
             }
 
+    - packaging:
+        vars:
+          homepage: https://github.com/pypa/packaging/
+          license: '|| ( Apache-2.0 BSD-2 )'
+        pydeps_ignore:
+          - 'extra == "test"'
+        selector:
+          - '<25'
+
+
 setuptools_modules:
   generator: builtin-pypi
   template:

--- a/python-modules-kit/merge.kit.d/base.yml
+++ b/python-modules-kit/merge.kit.d/base.yml
@@ -308,7 +308,6 @@ target:
     - pkg: dev-python/hatchling
     - pkg: dev-python/hatch-fancy-pypi-readme
     - pkg: dev-python/hatch-requirements-txt
-    - pkg: dev-python/packaging
     - pkg: dev-python/packaging-legacy
     - pkg: dev-python/poetry-core
     - pkg: dev-python/pdm-backend

--- a/python-modules-kit/merge.kit.d/python_autogen.yml
+++ b/python-modules-kit/merge.kit.d/python_autogen.yml
@@ -24,5 +24,6 @@ target:
     - pkg: dev-python/jeepney
     - pkg: dev-python/jinja
     - pkg: dev-python/yarl
+    - pkg: dev-python/packaging
     - pkg: dev-python/propcache
     - pkg: dev-python/setuptools_scm_git_archive


### PR DESCRIPTION
* keep version <25 for now
* using flit engine for building. This seems fix the version.

Closes: macaroni-os/mark-issues#346