### PR TITLE
[python-modules-kit] dev-python/setuptools_scm autogen

### DIFF
--- a/python-modules-kit/autogen.kit.d/python.yml
+++ b/python-modules-kit/autogen.kit.d/python.yml
@@ -246,3 +246,29 @@ standalone_modules:
               distutils-r1_python_compile
             }
 
+    - setuptools_scm:
+        pypi_name: setuptools_scm
+        pydeps:
+          py:all:runtime:
+            - tomli
+            - packaging
+            - importlib_metadata
+          py:all:build:
+            - tomli
+            - packaging
+            - importlib_metadata
+        vars:
+          license: MIT
+          homepage: https://github.com/pypa/setuptools-scm/
+          body: |
+            src_configure() {
+              if has_version "<dev-python/setuptools_scm-8"; then # only happens when setuptools_scm-7 is installed (main cause is duplicated entry points in similar fashion as in https://github.com/pypa/setuptools/issues/3649)
+                # it could be done better, but only side effect is two aditional internal unused api files added
+                # tested with python 3.12 - the duplicated entries where gone and update worked correctly without any quick fixes
+                ewarn "adding /src/setuptools_scm/{file_finder_git.py,file_hinder_hg.py} which point to _file_finders.{git,hg} modules due to build tools interaction"
+                echo "from ._file_finders.git import *" > ${S}/src/setuptools_scm/file_finder_git.py
+                echo "from ._file_finders.hg import *" >  ${S}/src/setuptools_scm/file_finder_hg.py
+              fi
+              distutils-r1_src_configure
+            }
+

--- a/python-modules-kit/merge.kit.d/base.yml
+++ b/python-modules-kit/merge.kit.d/base.yml
@@ -313,7 +313,6 @@ target:
     - pkg: dev-python/pdm-backend
     - pkg: dev-python/pdm-pep517
     - pkg: dev-python/setuptools-rust
-    - pkg: dev-python/setuptools_scm
     - pkg: dev-python/pyrfc3339
     - pkg: dev-python/python-xlib
     - pkg: dev-python/semantic_version

--- a/python-modules-kit/merge.kit.d/python_autogen.yml
+++ b/python-modules-kit/merge.kit.d/python_autogen.yml
@@ -26,4 +26,5 @@ target:
     - pkg: dev-python/yarl
     - pkg: dev-python/packaging
     - pkg: dev-python/propcache
+    - pkg: dev-python/setuptools_scm
     - pkg: dev-python/setuptools_scm_git_archive


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#350

# doit

```
$ mark-devkit doit   --specfile autogen.kit.d/python.yml --kitfile merge.kit.d/python_autogen.yml  --pkg setuptools_scm 
😷 Loading specfile autogen.kit.d/python.yml
🏰 Work directory:	workdir
🚀 Target Kit:		python-modules-kit
🏭 [hatchling_modules] Processing definition ...
🏭 [flit_modules] Processing definition ...
🏭 [setuptools_modules] Processing definition ...
🏭 [standalone_modules] Processing definition ...
🏭 [standalone_modules] Processing atom setuptools_scm...
🍕 [setuptools_scm] For package dev-python/setuptools_scm selected version 8.3.1
🎉 All done
```

# testing

```
>>> Installing (1 of 1) dev-python/setuptools_scm-8.3.1::python-modules-kit

>>> Recording dev-python/setuptools_scm in "world" favorites file...
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
```