### PR TITLE
[qt-kit] Minor corrections to dev-qt/qt{charts,positioning,webengine}

### DIFF
--- a/qt-kit/autogen.kit.d/qt5.yml
+++ b/qt-kit/autogen.kit.d/qt5.yml
@@ -110,6 +110,7 @@ dev-qt:
           depend: ${RDEPEND}
           bdepend: |
             ${PYTHON_DEPS}
+            dev-python/html5lib
             dev-util/gperf
             dev-util/ninja
             dev-util/re2c
@@ -231,7 +232,7 @@ dev-qt:
           iuse: geoclue +qml
           rdepend: |
             dev-qt/qtcore:{{ .Values.slot }}
-            geoclue? ( dev-qt/qtdbus:{{ .Values.slot }}
+            geoclue? ( dev-qt/qtdbus:{{ .Values.slot }} )
             qml? ( dev-qt/qtdeclarative:{{ .Values.slot }} )
           depend: ${RDEPEND}
           pdepend: |
@@ -287,7 +288,7 @@ dev-qt:
         vars:
           desc: "Chart component library for the Qt5 framework"
           license: GPL-3
-          iuse: qml
+          iuse: qml vulkan
           rdepend: |
             dev-qt/qtcore:{{ .Values.slot }}
             dev-qt/qtgui:{{ .Values.slot }}[vulkan=]


### PR DESCRIPTION
These three packages don't install without fixes.  The result is an inconsistent system with a mixture of old and new versions of Qt libraries.  All the Qt packages emerge at the expected version (now, `5.15.16`) with these changes.