### PR TITLE
[mark-unstable] Add `USE=zstd` for `sys-apps/kmod` to core flavor

### DIFF
--- a/core-kit/profiles/funtoo/1.0/linux-gnu/flavor/core/package.use/kmod
+++ b/core-kit/profiles/funtoo/1.0/linux-gnu/flavor/core/package.use/kmod
@@ -1,0 +1,2 @@
+# Needed for compressed module support
+sys-apps/kmod zstd


### PR DESCRIPTION
This adjustment is needed for compressed module support.