### PR TITLE
[kernel-kit] Update debian-sources for new Debian release; bugfixes

### DIFF
--- a/kernel-kit/autogen.kit.d/debian.yml
+++ b/kernel-kit/autogen.kit.d/debian.yml
@@ -24,6 +24,7 @@ debian_sources:
       rdepend: |
         sys-apps/gawk
         dracut? (
+          sys-apps/whip-catalog
           sys-kernel/dracut
           virtual/dracut-mark
         )
@@ -33,6 +34,7 @@ debian_sources:
         zfs? ( sys-fs/zfs )
         luks? ( sys-fs/cryptsetup )
         lvm? ( sys-fs/lvm2 )
+        mdadm? ( sys-fs/mdadm )
       required_use: |
         binary? (
           ^^ ( dracut )
@@ -60,7 +62,7 @@ debian_sources:
     - debian-sources:
         vars:
           level: testing
-          branch: trixie
+          branch: forky
           slot: trixie
           track_openzfs: True
           patches:
@@ -69,6 +71,15 @@ debian_sources:
     - debian-sources:
         vars:
           level: stable
+          branch: trixie
+          slot: trixie
+          track_openzfs: True
+          patches:
+            - 6.1.79+/more-ISA-levels-and-uarches-for-kernel-6.1.79+.patch
+          config_extract: 6.6
+    - debian-sources:
+        vars:
+          level: oldstable
           branch: bookworm
           slot: bookworm
           track_openzfs: True

--- a/kernel-kit/autogen.kit.d/templates/debian-sources.tmpl
+++ b/kernel-kit/autogen.kit.d/templates/debian-sources.tmpl
@@ -34,7 +34,7 @@ DEB_PV="${KERNEL_TRIPLET}-${DEB_PATCHLEVEL}"
 
 RESTRICT="binchecks strip"
 LICENSE="{{ .Values.license }}"
-KEYWORDS="{{- if ne .Values.level "unstable" }}*{{- end }}"
+KEYWORDS="*"
 IUSE="{{ .Values.iuse }}"
 
 RDEPEND="{{ .Values.rdepend }}"
@@ -373,15 +373,18 @@ pkg_postinst() {
 	# Finally, generate a new initramfs with dracut, via whip
 	# NOTE: For now, the initramfs is generic.
 	if use binary && use dracut; then
-		DRACUT_ADD_MODULES="
+		dracut_modules_pre="
 			$(use lvm && echo lvm)
 			$(use luks && echo crypt)
-			$(use mdadm && echo dmraid)
+			$(use mdadm && echo mdraid)
 			$(use btrfs && echo btrfs)
 			$(use sshd && echo sshd)
-		" DRACUT_ADD_DRIVERS="
+		"
+		dracut_drivers_pre="
 			$(use luks && echo dm-crypt)
-		" \
+		"
+		DRACUT_ADD_MODULES="$(echo ${dracut_modules_pre} | xargs)" \
+		DRACUT_ADD_DRIVERS="$(echo ${dracut_drivers_pre} | xargs)" \
 		KVER="${KERN_ARCH}-${MACARONI_KVER}" \
 		KTYPE="${MACARONI_KTYPE}" \
 		KSUFFIX="${MACARONI_KSUFFIX}" \


### PR DESCRIPTION
Specifically:
- add forky as new testing release
- change trixie to stable
- change bookwork to oldstable
- set KEYWORDS="*" for all versions

Bugfixes:
- dmraid -> mdraid, for mdadm
- send strictly "space-separated lists" to dracut
- `USE=mdadm` should pull in `sys-fs/mdadm` as dep
- ebuild needs to depend on `whip-catalog`

It will be necessary to mask sid in the profiles of testing/stable branches.  (Done)
