### PR TITLE
[core-gl-kit] nvidia-kernel-modules maintenance & bugfix

### DIFF
--- a/core-gl-kit/autogen.kit.d/templates/nvidia-kernel-modules.tmpl
+++ b/core-gl-kit/autogen.kit.d/templates/nvidia-kernel-modules.tmpl
@@ -10,8 +10,7 @@ SRC_URI=""
 
 LICENSE="GPL-2 NVIDIA-r2"
 SLOT="{{ .Values.slot }}"
-KEYWORDS="-* ~amd64 ~arm64"
-RESTRICT="bindist"
+KEYWORDS="*"
 
 IUSE="+kms +uvm videogroup open-kernel"
 
@@ -156,6 +155,11 @@ pkg_postinst() {
 	einfo "app-admin/gpu-configurator tool."
 	einfo "Uses: gpu-configurator nvidia kernel ${PV} [kernel-version]"
 	einfo "to add hardlink to kernel path and/or to change configuration."
+}
+
+pkg_postrm() {
+	einfo "Try to run gpu-configurator nvidia kernel --purge ${PV} ${KV_FULL} ..."
+	gpu-configurator nvidia kernel --purge ${PV} ${KV_FULL} || true
 }
 
 # vim: filetype=ebuild


### PR DESCRIPTION
There are three changes:
- set KEYWORDS="*", since we don't mix stability levels in a given branch;
- add a pkg_postrm hook to purge the kernel modules;
- remove RESTRICT='bindist'.

The change to `bindist` is worth considering.  Maybe it's not what we want.  In the case that the kernel is updated, the binary modules will install correctly, but won't work.  Portage doesn't know this and won't warn the user, unless we add a warning message to the log at the end.