### PR TITLE
[net-kit] Add socat as a build dependency for flatpak

### DIFF
--- a/net-kit/autogen.kit.d/base.yml
+++ b/net-kit/autogen.kit.d/base.yml
@@ -901,6 +901,7 @@ flatpak:
             $(python_gen_any_dep '
               dev-python/pyparsing[${PYTHON_USEDEP}]
             ')
+            net-misc/socat
           pdepend: |
             gnome? (
               sys-apps/xdg-desktop-portal


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#552