### PR TITLE
[dev-kit] Autogen `dev-util/cmocka`

### DIFF
--- a/dev-kit/autogen.kit.d/base.yml
+++ b/dev-kit/autogen.kit.d/base.yml
@@ -2136,3 +2136,58 @@ talloc:
               use python && python_optimize
             }
 
+
+cmocka:
+  generator: builtin-dirlisting
+  generator_opts:
+    # Limit rate at 1reqs/sec
+    rate_limiter: "1"
+
+  defaults:
+    files_dir: "{{ .Values.pn }}"
+    template: ../../templates/simple.tmpl
+    category: dev-util
+    dir:
+      url: 'https://cmocka.org/files/2.0'
+      matcher: "{{ .Values.pn }}-.*.tar.xz$"
+    transform:
+      - kind: string
+        match: "{{ .Values.pn }}-"
+        replace: ""
+      - kind: string
+        match: ".tar.xz"
+        replace: ""
+    vars:
+      desc: 'An elegant unit testing framework for C with support for mock objects'
+      extra_envs:
+        - "DOCS=( AUTHORS CHANGELOG.md README.md )"
+      homepage: https://cmocka.org/
+      inherit:
+        - cmake
+      iuse: doc examples static-libs test
+      license: Apache-2.0
+      bdepend: |
+        doc? ( app-doc/doxygen[dot] )
+      body: |
+        src_configure() {
+          local mycmakeargs=(
+            -DWITH_EXAMPLES=$(usex examples)
+            -DWITH_STATIC_LIB=$(usex static-libs)
+            -DWITH_TESTING=$(usex test)
+            $(cmake-utils_use_find_package doc Doxygen \
+              || echo -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON)
+          )
+          cmake_src_configure
+        }
+        src_compile() {
+          cmake-utils_src_compile
+          use doc && cmake_src_compile docs
+        }
+        src_install() {
+          if use doc; then
+            local HTML_DOCS=( "${BUILD_DIR}"/doc/html/. )
+          fi
+          cmake_src_install
+        }
+  packages:
+    - cmocka:

--- a/dev-kit/merge.kit.d/base.yml
+++ b/dev-kit/merge.kit.d/base.yml
@@ -218,7 +218,6 @@ target:
     - pkg: dev-util/byacc
     - pkg: dev-util/ccache
     - pkg: dev-util/clinfo
-    - pkg: dev-util/cmocka
     - pkg: dev-util/cscope
     - pkg: dev-util/debootstrap
     - pkg: dev-util/eclipse-sdk-bin:2024.06

--- a/dev-kit/merge.kit.d/base_autogen.yml
+++ b/dev-kit/merge.kit.d/base_autogen.yml
@@ -51,6 +51,7 @@ target:
     - pkg: dev-util/cbindgen
     - pkg: dev-util/clion
     - pkg: dev-util/cmake
+    - pkg: dev-util/cmocka
     - pkg: dev-util/datagrip
     - pkg: dev-util/go-swagger
     - pkg: dev-util/goland


### PR DESCRIPTION
This package is required by `sys-auth/sssd` and wasn't autogen in our tree.

There is also a version `cmocka-1.1.x`, in case this one gives us trouble with other packages.  So far, so good!