### PR TITLE
[core-server-kit] app-emulation/qemu Make qemu-7.2.16-optionrom-pass-…

### DIFF
--- a/core-server-kit/autogen.kit.d/qemu/qemu-7.2.16-optionrom-pass-Wl-no-error-rwx-segments.patch
+++ b/core-server-kit/autogen.kit.d/qemu/qemu-7.2.16-optionrom-pass-Wl-no-error-rwx-segments.patch
@@ -19,19 +19,12 @@ Pass -Wl,--no-error-rwx-segments to suppress that.
  1 file changed, 1 insertion(+)
 
 diff --git a/pc-bios/optionrom/Makefile b/pc-bios/optionrom/Makefile
-index 30d07026c7..4d3ce75af3 100644
 --- a/pc-bios/optionrom/Makefile
 +++ b/pc-bios/optionrom/Makefile
-@@ -37,6 +37,7 @@ config-cc.mak: Makefile
- -include config-cc.mak
- 
+@@ -39,2 +39,3 @@
  override LDFLAGS = -nostdlib -Wl,--build-id=none,-T,$(SRC_DIR)/flat.lds
 +override LDFLAGS += -Wl,--no-error-rwx-segments
  
- pvh.img: pvh.o pvh_main.o
- 
-
-base-commit: 40efe733e10cc00e4fb4f9f5790a28e744e63c62
 -- 
 2.48.1
 


### PR DESCRIPTION
…Wl-no-error-rwx-segments.patch applicable to `pc-bios/optionrom/Makefile` for `10.2.0` and `10.2.1`

Closes: macaroni-os/mark-issues#583

```test-mark-unstable / # emerge -av =app-emulation/qemu-10.2.0
--- Invalid atom in /var/git/meta-repo/kits/core-kit/profiles/funtoo/1.0/linux-gnu/flavor/core/package.use/qt5: Slot deps are not allowed in EAPI 0: 'dev-qt/qtwebengine:5'

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild   R    ] app-emulation/qemu-10.2.0::core-server-kit  USE="aio bzip2 curl fdt filecaps gnutls jpeg ncurses nls oss pam pin-upstream-blobs png python seccomp slirp static-user usb usbredir vhost-net vnc xattr -accessibility -alsa -bpf -capstone -debug -doc -fuse -glusterfs -gtk -infiniband -io-uring -iscsi -jack -jemalloc -keyutils -lzo -multipath -nfs -numa -opengl -passt -plugins -pulseaudio -rbd -sasl -sdl -sdl-image -smartcard -snappy -spice -ssh -static -systemtap -udev -vde -vhost-user-fs -virgl -virtfs -vte -xen -zstd" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8" QEMU_SOFTMMU_TARGETS="i386 x86_64 -aarch64 -alpha -arm -avr -hppa -loongarch64 -m68k -microblaze -microblazeel -mips -mips64 -mips64el -mipsel -nios2 -or1k -ppc -ppc64 -riscv32 -riscv64 -rx -s390x -sh4 -sh4eb -sparc -sparc64 -tricore -xtensa -xtensaeb" QEMU_USER_TARGETS="aarch64 arm i386 ppc64 riscv64 x86_64 -aarch64_be -alpha -armeb -hexagon -hppa -loongarch64 -m68k -microblaze -microblazeel -mips -mips64 -mips64el -mipsel -mipsn32 -mipsn32el -nios2 -or1k -ppc -ppc64le -riscv32 -s390x -sh4 -sh4eb -sparc -sparc32plus -sparc64 -xtensa -xtensaeb" 0 KiB

Total: 1 package (1 reinstall), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 

>>> Verifying ebuild manifests

>>> Emerging (1 of 1) app-emulation/qemu-10.2.0::core-server-kit
 * qemu-10.2.0.tar.xz BLAKE2B SHA512 size ;-) ...                                                                                                                                                                                                                                  [ ok ]
>>> Unpacking source...
>>> Unpacking qemu-10.2.0.tar.xz to /var/tmp/portage/app-emulation/qemu-10.2.0/work
>>> Source unpacked in /var/tmp/portage/app-emulation/qemu-10.2.0/work
>>> Preparing source in /var/tmp/portage/app-emulation/qemu-10.2.0/work/qemu-10.2.0 ...
 * Applying qemu-10.1.2-fix_passt.patch ...                                                                                                                                                                                                                                        [ ok ]
 * Applying qemu-9.0.0-disable-keymap.patch ...                                                                                                                                                                                                                                    [ ok ]
 * Applying qemu-9.2.0-capstone-include-path.patch ...                                                                                                                                                                                                                             [ ok ]
 * Applying qemu-8.1.0-skip-tests.patch ...                                                                                                                                                                                                                                        [ ok ]
 * Applying qemu-8.1.0-find-sphinx.patch ...                                                                                                                                                                                                                                       [ ok ]
 * Applying qemu-7.2.16-optionrom-pass-Wl-no-error-rwx-segments.patch ...                                                                                                                                                                                                          [ ok ]
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/app-emulation/qemu-10.2.0/work/qemu-10.2.0 ...
 * Using python3.9 in global scope
CONFIG_VHOST_USER_FS=n for i386-softmmu
CONFIG_VHOST_USER_FS=n for x86_64-softmmu
../configure --prefix=/usr --sysconfdir=/etc --bindir=/usr/bin --libdir=/usr/lib64 --datadir=/usr/share --docdir=/usr/share/doc/qemu-10.2.0/html --mandir=/usr/share/man --localstatedir=/var --disable-bsd-user --disable-containers --disable-guest-agent --disable-strip --disable-tcg-interpreter --disable-werror --disable-gcrypt --python=/usr/bin/python3.9 --cc=x86_64-pc-linux-gnu-gcc --cxx=x86_64-pc-linux-gnu-g++ --host-cc=x86_64-pc-linux-gnu-gcc --disable-alsa --disable-debug-info --disable-debug-tcg --disable-jack --enable-gettext --enable-oss --disable-plugins --disable-pa --enable-attr --disable-selinux --disable-brlapi --enable-linux-aio --disable-bpf --enable-bzip2 --disable-capstone --enable-curl --disable-docs --enable-fdt --disable-fuse --disable-glusterfs --enable-gnutls --enable-nettle --disable-gtk --disable-rdma --disable-libiscsi --disable-linux-io-uring --enable-vnc-jpeg --enable-kvm --disable-lzo --disable-mpath --enable-curses --disable-libnfs --disable-numa --disable-opengl --enable-auth-pam --enable-png --disable-rbd --disable-vnc-sasl --disable-sdl --disable-sdl-image --enable-seccomp --enable-slirp --disable-smartcard --disable-snappy --disable-spice --disable-libssh --disable-libudev --enable-libusb --enable-usb-redir --disable-vde --enable-vhost-net --disable-virglrenderer --disable-virtfs --enable-vnc --disable-vte --disable-xen --disable-xen-pci-passthrough --disable-xkbcommon --disable-zstd --enable-gio --audio-drv-list=oss --disable-linux-user --enable-system --disable-tools --enable-cap-ng --enable-seccomp --target-list=i386-softmmu,x86_64-softmmu --enable-pie
^C

Exiting on signal 2
test-mark-unstable / # emerge -av =app-emulation/qemu-10.2.1
--- Invalid atom in /var/git/meta-repo/kits/core-kit/profiles/funtoo/1.0/linux-gnu/flavor/core/package.use/qt5: Slot deps are not allowed in EAPI 0: 'dev-qt/qtwebengine:5'

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild     U  ] app-emulation/qemu-10.2.1::core-server-kit [10.2.0::core-server-kit] USE="aio bzip2 curl fdt filecaps gnutls jpeg ncurses nls oss pam pin-upstream-blobs png python seccomp slirp static-user usb usbredir vhost-net vnc xattr -accessibility -alsa -bpf -capstone -debug -doc -fuse -glusterfs -gtk -infiniband -io-uring -iscsi -jack -jemalloc -keyutils -lzo -multipath -nfs -numa -opengl -passt -plugins -pulseaudio -rbd -sasl -sdl -sdl-image -smartcard -snappy -spice -ssh -static -systemtap -udev -vde -vhost-user-fs -virgl -virtfs -vte -xen -zstd" PYTHON_TARGETS="python3_9 -python3_10 -python3_7 -python3_8" QEMU_SOFTMMU_TARGETS="i386 x86_64 -aarch64 -alpha -arm -avr -hppa -loongarch64 -m68k -microblaze -microblazeel -mips -mips64 -mips64el -mipsel -nios2 -or1k -ppc -ppc64 -riscv32 -riscv64 -rx -s390x -sh4 -sh4eb -sparc -sparc64 -tricore -xtensa -xtensaeb" QEMU_USER_TARGETS="aarch64 arm i386 ppc64 riscv64 x86_64 -aarch64_be -alpha -armeb -hexagon -hppa -loongarch64 -m68k -microblaze -microblazeel -mips -mips64 -mips64el -mipsel -mipsn32 -mipsn32el -nios2 -or1k -ppc -ppc64le -riscv32 -s390x -sh4 -sh4eb -sparc -sparc32plus -sparc64 -xtensa -xtensaeb" 0 KiB

Total: 1 package (1 upgrade), Size of downloads: 0 KiB

Would you like to merge these packages? [Yes/No] 

>>> Verifying ebuild manifests

>>> Emerging (1 of 1) app-emulation/qemu-10.2.1::core-server-kit
 * qemu-10.2.1.tar.xz BLAKE2B SHA512 size ;-) ...                                                                                                                                                                                                                                  [ ok ]
>>> Unpacking source...
>>> Unpacking qemu-10.2.1.tar.xz to /var/tmp/portage/app-emulation/qemu-10.2.1/work
>>> Source unpacked in /var/tmp/portage/app-emulation/qemu-10.2.1/work
>>> Preparing source in /var/tmp/portage/app-emulation/qemu-10.2.1/work/qemu-10.2.1 ...
 * Applying qemu-10.1.2-fix_passt.patch ...                                                                                                                                                                                                                                        [ ok ]
 * Applying qemu-9.0.0-disable-keymap.patch ...                                                                                                                                                                                                                                    [ ok ]
 * Applying qemu-9.2.0-capstone-include-path.patch ...                                                                                                                                                                                                                             [ ok ]
 * Applying qemu-8.1.0-skip-tests.patch ...                                                                                                                                                                                                                                        [ ok ]
 * Applying qemu-8.1.0-find-sphinx.patch ...                                                                                                                                                                                                                                       [ ok ]
 * Applying qemu-7.2.16-optionrom-pass-Wl-no-error-rwx-segments.patch ...
patching file pc-bios/optionrom/Makefile
Hunk #1 succeeded at 39 with fuzz 1.                                                                                                                                                                                                                                               [ ok ]
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/app-emulation/qemu-10.2.1/work/qemu-10.2.1 ...
 * Using python3.9 in global scope
CONFIG_VHOST_USER_FS=n for i386-softmmu
CONFIG_VHOST_USER_FS=n for x86_64-softmmu
```