### PR TITLE
[python-kit] Fix `doman` path for uncompressed man files in autogen script

### DIFF
--- a/python-kit/autogen.kit.d/base.yml
+++ b/python-kit/autogen.kit.d/base.yml
@@ -246,7 +246,7 @@ python:
               "${scriptdir}/idle" || die
           fi
           # eselect-python requires compress man files
-          doman /share/man/man1/python{{ .Values.slot }}.1
+          doman "${ED}"/share/man/man1/python{{ .Values.slot }}.1
           # remove uncompressed man files
           rm -r "${ED}"/share/man
         }


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#586