### PR TITLE
[core-server-kit] Add app-crypt/certbot autogen (and friends in python-modules-kit)

### DIFF
--- a/core-server-kit/autogen.kit.d/tools.yml
+++ b/core-server-kit/autogen.kit.d/tools.yml
@@ -3116,3 +3116,167 @@ gitlab_runner_bin:
 
   packages:
     - gitlab-runner-bin:
+
+certbot:
+  generator: builtin-github
+  defaults:
+    category: app-crypt
+    template: ../../templates/simple-github.tmpl
+    files_dir: "{{ .Values.pn }}"
+    github:
+      user: certbot
+      repo: certbot
+      query: releases
+    transform:
+      - kind: string
+        match: 'Certbot '
+        replace: ''
+    vars:
+      desc: "Let's Encrypt client to automate deployment of X.509 certificates"
+      du_pep517: setuptools
+      extra_envs:
+        - 'CERTBOT_BASE=(acme certbot)'
+        - 'CERTBOT_DIRS=()'
+        - 'CERTBOT_DOCS="${T}/docs"'
+        - |
+          # List of "subpackages" from tools/_release.sh (without acme which is already above)
+          CERTBOT_MODULES_EXTRA=(
+            apache
+            dns-cloudflare
+            dns-digitalocean
+            dns-dnsimple
+            dns-dnsmadeeasy
+            dns-gehirn
+            dns-google
+            dns-linode
+            dns-luadns
+            dns-nsone
+            dns-ovh
+            dns-rfc2136
+            dns-route53
+            dns-sakuracloud
+            nginx
+          )
+      homepage: |-
+        https://github.com/certbot/certbot
+        https://pypi.org/project/certbot/
+        https://letsencrypt.org/
+      inherit:
+        - distutils-r1
+        - toolchain-funcs
+      iuse: certbot-apache certbot-dns-dnsimple certbot-dns-dnsmadeeasy certbot-dns-gehirn certbot-dns-google certbot-dns-linode certbot-dns-luadns certbot-dns-nsone certbot-dns-ovh certbot-dns-rfc2136 certbot-dns-route53 certbot-dns-sakuracloud certbot-nginx
+      keywords: '*'
+      license: Apache-2.0
+      python_compat: python3+
+      slot: 0
+      rdepend: |
+        dev-python/configargparse[${PYTHON_USEDEP}]
+        dev-python/configobj[${PYTHON_USEDEP}]
+        dev-python/cryptography[${PYTHON_USEDEP}]
+        dev-python/distro[${PYTHON_USEDEP}]
+        dev-python/josepy[${PYTHON_USEDEP}]
+        dev-python/parsedatetime[${PYTHON_USEDEP}]
+        dev-python/pyopenssl[${PYTHON_USEDEP}]
+        dev-python/pyrfc3339[${PYTHON_USEDEP}]
+        dev-python/requests[${PYTHON_USEDEP}]
+        certbot-apache? (
+          dev-python/python-augeas[${PYTHON_USEDEP}]
+        )
+        certbot-cloudflare? {
+          dev-python/cloudflare[${PYTHON_USEDEP}]
+        }
+        certbot-digitalocean? {
+          dev-python/digitalocean[${PYTHON_USEDEP}]
+        }
+        certbot-dns-dnsimple? (
+          dev-python/dns-lexicon[${PYTHON_USEDEP}]
+        )
+        certbot-dns-dnsmadeeasy? (
+          dev-python/dns-lexicon[${PYTHON_USEDEP}]
+        )
+        certbot-dns-gehirn? (
+          dev-python/dns-lexicon[${PYTHON_USEDEP}]
+        )
+        certbot-dns-google? (
+          dev-python/google-api-python-client[${PYTHON_USEDEP}]
+          dev-python/google-auth[${PYTHON_USEDEP}]
+        )
+        certbot-dns-linode? (
+          dev-python/dns-lexicon[${PYTHON_USEDEP}]
+        )
+        certbot-dns-luadns? (
+          dev-python/dns-lexicon[${PYTHON_USEDEP}]
+        )
+        certbot-dns-nsone? (
+          dev-python/dns-lexicon[${PYTHON_USEDEP}]
+        )
+        certbot-dns-ovh? (
+          dev-python/dns-lexicon[${PYTHON_USEDEP}]
+        )
+        certbot-dns-rfc2136? (
+          dev-python/dnspython[${PYTHON_USEDEP}]
+        )
+        certbot-dns-route53? (
+          dev-python/boto3[${PYTHON_USEDEP}]
+        )
+        certbot-dns-sakuracloud? (
+          dev-python/dns-lexicon[${PYTHON_USEDEP}]
+        )
+        certbot-nginx? (
+          dev-python/pyopenssl[${PYTHON_USEDEP}]
+          dev-python/pyparsing[${PYTHON_USEDEP}]
+        )
+
+      restrict: strip
+      body: |
+        distutils_enable_sphinx docs dev-python/spinx-rtd-theme
+        src_prepare() {
+          default
+
+          local base module
+          for base in "${CERTBOT_BASE[@]}"; do
+            CERTBOT_DIRS+=("${base}")
+          done
+          for module in "${CERTBOT_MODULES_EXTRA[@]}"; do
+            use "certbot-${module}" &&
+              CERTBOT_DIRS+=("certbot-${module}")
+          done
+          # Used to build documentation
+          mkdir "${CERTBOT_DOCS}" || die
+          # Remove "broken" symbolic link used as documentation.
+          # Copy actual file; removing source breaks wheel building.
+          rm -f "${S}/README.rst"
+          cp "${S}/certbot/README.rst" "${S}/README.rst" || die
+        }
+
+        python_compile() {
+          local dir
+          for dir in "${CERTBOT_DIRS[@]}"; do
+            pushd "${dir}"
+            distutils-r1_python_compile
+            popd > /dev/null || die
+          done
+        }
+
+        python_compile_all() {
+          use doc || return
+          local dir
+          for dir in "${CERTBOT_DIRS[@]}"; do
+            # There is no documentation in certbot-apache or certbot-nginx.
+            if has "${dir}" "certbot-apache" "certbot-nginx"; then
+              continue
+            fi
+            pushd "${dir}" > /dev/null || die
+            sphinx_compile_all
+            # Note: discard the `/.` in last entry suffix to avoid error
+            # with `mv` command.
+            mv "${HTML_DOCS[-1]%/.}" "${CERTBOT_DOCS}/${dir}" || die
+            popd > /dev/null || die
+          done
+          # And finally give the result.
+          # Note: the suffix `/.` here is to discard the holding directory.
+          HTML_DOCS=( "${CERTBOT_DOCS}/." )
+        }
+
+  packages:
+    - certbot:

--- a/core-server-kit/merge.kit.d/tools_autogen.yml
+++ b/core-server-kit/merge.kit.d/tools_autogen.yml
@@ -24,6 +24,8 @@ target:
     - pkg: app-backup/backrest
     - pkg: app-backup/restic
 
+    - pkg: app-crypt/certbot
+
     - pkg: app-emulation/containerd
     - pkg: app-emulation/docker
     - pkg: app-emulation/docker-buildx
@@ -31,6 +33,7 @@ target:
     - pkg: app-emulation/docker-compose
     - pkg: app-emulation/docker-registry
     - pkg: app-emulation/firecracker-bin
+
     - pkg: app-emulation/qemu
     - pkg: app-emulation/runc
     - pkg: app-emulation/lxc

--- a/python-modules-kit/autogen.kit.d/python.yml
+++ b/python-modules-kit/autogen.kit.d/python.yml
@@ -10,6 +10,18 @@ hatchling_modules:
       du_pep517: hatchling
 
   packages:
+    - dns-lexicon:
+      pydeps:
+        py:all:
+          - beautifulsoup
+          - cryptography
+          - dnspython
+          - importlib-metadata
+          - pyotp
+          - pyyaml
+          - requests
+          - tldextract
+
     - expandvars:
         pydeps_ignore:
           - "extra == 'tests'"
@@ -173,6 +185,13 @@ setuptools_modules:
 
   packages:
 
+    - boto3:
+        pydeps:
+          py:all:
+            - botocore
+            - jmespath
+            - s3transfer
+
     - calver:
         vars:
           license: Apache-2.0
@@ -186,7 +205,7 @@ setuptools_modules:
         vars:
           rdepend: app-misc/ca-certificates
 
-
+    - configargparse:
 
     - dependency-injector:
         pypi_name: dependency_injector
@@ -239,6 +258,8 @@ setuptools_modules:
           py:all:runtime:
             - six
             - webencodings
+
+    - parsedatetime:
 
     - pycamera:
         vars:
@@ -321,6 +342,11 @@ poetry_modules:
     python_compat: "python3+"
 
   packages:
+    - josepy:
+        pydeps:
+          py:all:
+            - cryptography
+
     - qrcode:
 
 standalone_modules:

--- a/python-modules-kit/merge.kit.d/python_autogen.yml
+++ b/python-modules-kit/merge.kit.d/python_autogen.yml
@@ -13,16 +13,20 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: dev-python/boto3
     - pkg: dev-python/brotlipy
     - pkg: dev-python/cachecontrol
     - pkg: dev-python/calver
     - pkg: dev-python/certifi
+    - pkg: dev-python/configargparse
     - pkg: dev-python/cryptography
     - pkg: dev-python/dependency-injector
     - pkg: dev-python/distlib
+    - pkg: dev-python/dns-lexicon
     - pkg: dev-python/expandvars
     - pkg: dev-python/embit
     - pkg: dev-python/falcon
+    - pkg: dev-python/josepy
     - pkg: dev-python/libxml2-python
     - pkg: dev-python/libxslt-python
     - pkg: dev-python/llfuse
@@ -35,6 +39,7 @@ target:
     - pkg: dev-python/yarl
     - pkg: dev-python/monero
     - pkg: dev-python/packaging
+    - pkg: dev-python/parsedatetime
     - pkg: dev-python/pycamera
     - pkg: dev-python/pycairo
     - pkg: dev-python/pycotap


### PR DESCRIPTION
This PR adds an autogen for `certbot`, based on the Gentoo ebuild.

It also adds Python deps required for `certbot` to python-modules-kit:
- boto3
- cloudflare (TBD)
- configargparse
- digitalocean (TBD)
- dns-lexicon
  - pyotp (TBD)
  - tldextract (TBD)
- google-api-python-client (TBD)
- google-auth (TBD)
- josepy
- parsedatetime
- python-augeas (TBD)

The Python deps are a bit of a pain to deal with.  Will mark this PR as a draft for now, since the deps won't resolve.