### PR TITLE
[python-kit] dev-python/cryptography Remove test directories during `python_install` in autogen script

### DIFF
--- a/python-modules-kit/autogen.kit.d/python.yml
+++ b/python-modules-kit/autogen.kit.d/python.yml
@@ -595,6 +595,10 @@ cryptography:
                 cargo_src_unpack
               fi
             }
+            python_install() {
+              distutils-r1_python_install
+              rm -r "${D}$(python_get_sitedir)"/tests || die
+            }
 
 
 gnome_dirlisting:


### PR DESCRIPTION
Closes: macaroni-os/mark-issues#602