### PR TITLE
[kernel-kit] Autogen `sys-kernel/linux-headers` from kernel.org

### DIFF
--- a/kernel-kit/autogen.kit.d/base.yml
+++ b/kernel-kit/autogen.kit.d/base.yml
@@ -1,4 +1,4 @@
-net_vpn_dirlisting:
+linux_kernel_dirlisting:
   generator: builtin-dirlisting
   template:
     engine: helm
@@ -90,3 +90,98 @@ net_vpn_dirlisting:
               # Don't forget to umount /boot if it was previously mounted by us.
               use initramfs && ego_pkg_postrm
             }
+
+    - vanilla-headers:
+        dir:
+          url: https://mirrors.edge.kernel.org/pub/linux/kernel/v6.x/
+          matcher: 'linux-.*.tar.xz'
+        selector:
+          - '>6.12'
+          - '<6.13'
+        transform:
+          - kind: string
+            match: 'linux-'
+            replace: ''
+          - kind: string
+            match: '.tar.xz'
+            replace: ''
+        vars:
+          category: sys-kernel
+          bdepend: |
+            app-arch/xz-utils
+            dev-lang/perl
+            net-misc/rsync
+            !<sys-kernel/linux-headers-6.12
+            !!sys-kernel/debian-headers
+          desc: Linux kernel header files
+          homepage: https://kernel.org
+          inherit:
+            - eutils
+            - toolchain-funcs
+          license: GPL-2
+          patches:
+            - 00_all_0002-x86-do-not-build-relocs-tool-when-installing-headers.patch
+          restrict: binchecks strip
+          s: '${WORKDIR}/linux-${PV}'
+          body: |
+            pkg_setup() {
+              export REAL_ARCH="$ARCH"
+              # will interfere with Makefile if set
+              unset ARCH; unset LDFLAGS
+            }
+            src_prepare() {
+              default
+              # drop unused errno.h include
+              sed -e '/^#include <errno.h>/d' -i ${WORKDIR}/scripts/unifdef.c
+            }
+            src_compile() {
+              :
+            }
+            src_install() {
+              # fix permissions in source tree
+              cd "${WORKDIR}"
+              chown -R 0:0 * >& /dev/null
+              chmod -R a+r-w+X,u+w *
+              cd "${OLDPWD}"
+              [[ -L /usr/include/linux ]] && { rm /usr/include/linux || die; }
+              [[ -L /usr/include/asm ]] && { rm /usr/include/asm || die; }
+              emake O="${D}" ARCH="$(tc-arch-kernel)" headers_install \
+                || die "could not install headers to image"
+              # prune non-headers from tree
+              rm "${D}"/{arch,include,scripts} -r
+              find "${D}" '(' -name '.install' -o -name '*.cmd' ')' -delete
+            }
+
+virtual_os_headers:
+  generator: builtin-noop
+  defaults:
+    template: ../../templates/simple.tmpl
+    files_dir: "{{ .Values.pn }}"
+    ignore_artefacts: true
+  packages:
+    - linux-headers:
+        category: sys-kernel
+        vars:
+          depend: ${RDEPEND}
+          desc: "Virtual for Linux kernel headers"
+          homepage: https://kernel.org
+          license: GPL-2
+          rdepend: |
+            || (
+              >=sys-kernel/debian-headers-{{ .Values.version }}
+              >=sys-kernel/vanilla-headers-{{ .Values.version }}
+            )
+            !<sys-kernel/linux-headers-{{ addf .Values.version 0.01 }}
+            !>sys-kernel/debian-headers-{{ addf .Values.version 0.01 }}
+            !>sys-kernel/vanilla-headers-{{ addf .Values.version 0.01 }}
+          versions:
+            - '6.12'
+    - os-headers:
+        category: virtual
+        vars:
+          desc: "Virtual for operating system headers"
+          # Presently we only support Linux
+          depend: ${RDEPEND}
+          rdepend: sys-kernel/linux-headers
+          versions:
+            - '1'

--- a/kernel-kit/autogen.kit.d/debian.yml
+++ b/kernel-kit/autogen.kit.d/debian.yml
@@ -100,6 +100,81 @@ debian_sources:
             - 6.1.79+/more-ISA-levels-and-uarches-for-kernel-6.1.79+.patch
           config_extract: 6.1
 
+debian_headers:
+  generator: custom
+  generator_opts:
+    script: sys-kernel/debian-sources/generator.py
+    enable_set_version: 'false'
+  defaults:
+    category: sys-kernel
+    files_dir: vanilla-headers
+    template: ../../templates/simple.tmpl
+    vars:
+      bdepend: |
+        app-arch/xz-utils
+        dev-lang/perl
+        net-misc/rsync
+        !!sys-kernel/vanilla-headers
+      branch: trixie
+      desc: Linux kernel header files with Debian patches
+      patches:
+        - 00_all_0002-x86-do-not-build-relocs-tool-when-installing-headers.patch
+      homepage: https://kernel.org https://debian.org/kernel
+      inherit:
+        - eutils
+        - toolchain-funcs
+      level: stable
+      license: GPL-2
+      openzfs_meta_url: https://raw.githubusercontent.com/openzfs/zfs/zfs-2.3-release/META
+      slot: 0
+      s: '${WORKDIR}/linux-${PV%%_p*}'
+      track_openzfs: False
+      body: |
+        get_patch_list() {
+          [[ -z "${1}" ]] && die "No patch series file specified"
+          local patch_series="${1}"
+          while read line ; do
+            if [[ "${line:0:1}" != "#" ]] ; then
+              echo "${line}"
+            fi
+          done < "${patch_series}"
+        }
+        pkg_setup() {
+          # will interfere with Makefile if set
+          unset ARCH; unset LDFLAGS
+        }
+        src_prepare() {
+          default
+          # apply debian patchset
+          for debpatch in $( get_patch_list "${WORKDIR}/debian/patches/series" ); do
+            eapply -p1 "${WORKDIR}/debian/patches/${debpatch}" || die "could not apply patch!"
+          done
+          # drop unused errno.h include
+          sed -e '/^#include <errno.h>/d' -i ${WORKDIR}/scripts/unifdef.c
+        }
+        src_compile() {
+          :
+        }
+        src_install() {
+          # fix permissions in source tree
+          cd "${WORKDIR}"
+          chown -R 0:0 * >& /dev/null
+          chmod -R a+r-w+X,u+w *
+          cd "${OLDPWD}"
+          [[ -L /usr/include/linux ]] && { rm /usr/include/linux || die; }
+          [[ -L /usr/include/asm ]] && { rm /usr/include/asm || die; }
+          emake O="${D}" ARCH="$(tc-arch-kernel)" headers_install \
+            || die "could not install headers to image"
+          # prune non-headers from tree
+          rm "${D}"/{arch,include,scripts} -r
+          find "${D}" '(' -name '.install' -o -name '*.cmd' ')' -delete
+        }
+  packages:
+    - debian-headers:
+        selector:
+          - '>6.12'
+          - '<6.13'
+
 # TODO: move to separate file, as it's not specifically debian-sources--related
 dracut_config:
   generator: builtin-noop

--- a/kernel-kit/autogen.kit.d/vanilla-headers/00_all_0002-x86-do-not-build-relocs-tool-when-installing-headers.patch
+++ b/kernel-kit/autogen.kit.d/vanilla-headers/00_all_0002-x86-do-not-build-relocs-tool-when-installing-headers.patch
@@ -1,0 +1,33 @@
+From 57875de37c5375ea95e1e949ec7c741d0038d3a1 Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Sat, 15 Nov 2014 03:37:38 -0500
+Subject: [PATCH] x86: do not build relocs tool when installing headers
+
+This isn't needed to install headers, so don't bother building it.
+Otherwise we run into a chicken/egg issue where we need the kernel
+headers in order to install the kernel headers.  It's also a waste
+of time.
+
+Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+---
+ arch/x86/Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/x86/Makefile b/arch/x86/Makefile
+index 60135cbd905c..9b15b2daa77f 100644
+--- a/arch/x86/Makefile
++++ b/arch/x86/Makefile
+@@ -215,8 +215,10 @@
+ endif
+ 
+ 
++ifneq ($(filter-out headers_install,$(MAKECMDGOALS)),)
+ archscripts: scripts_basic
+ 	$(Q)$(MAKE) $(build)=arch/x86/tools relocs
++endif
+ 
+ ###
+ # Syscall table generation
+-- 
+2.16.1
+

--- a/kernel-kit/merge.kit.d/base.yml
+++ b/kernel-kit/merge.kit.d/base.yml
@@ -35,15 +35,11 @@ target:
   atoms:
     - pkg: sys-kernel/linux-headers
       conditions:
-        - '>=sys-kernel/linux-headers-6.9'
-        - '<sys-kernel/linux-headers-6.10'
-
-    - pkg: sys-kernel/linux-headers
-      conditions:
-        - '>=sys-kernel/linux-headers-5.10'
-        - '<sys-kernel/linux-headers-5.11'
+        - '>=sys-kernel/linux-headers-6.12'
+        - '<sys-kernel/linux-headers-6.13'
 
     - pkg: sys-kernel/dummy-sources
+    - pkg: sys-kernel/vanilla-headers
     - pkg: sys-kernel/vanilla-sources
 
     - pkg: sys-kernel/linux-firmware
@@ -56,5 +52,6 @@ target:
     - pkg: sys-apps/gptfdisk
 
     - pkg: virtual/os-headers
+    #- pkg: virtual/linux-headers
     - pkg: virtual/linux-sources
     - pkg: virtual/modutils

--- a/kernel-kit/merge.kit.d/debian.yml
+++ b/kernel-kit/merge.kit.d/debian.yml
@@ -13,6 +13,7 @@ target:
     max_versions: 3
 
   atoms:
+    - pkg: sys-kernel/debian-headers
     - pkg: sys-kernel/debian-sources:bookworm
     - pkg: sys-kernel/debian-sources:forky
     - pkg: sys-kernel/debian-sources:trixie


### PR DESCRIPTION
This PR adds an autogen for the kernel headers from the vanilla source package at kernel.org.  

The `debian-sources` kernel package pulls sources from the same place.

I've left the minor version on it so that we know where it came from.  As a result, kernel headers will get updated over time, from whatever branch we choose.  Perhaps we should use a `SLOT` so that kernel autogens can depend on the correct headers and block headers that are newer than the kernel.

Note that the merge step is taken care of here, but will need to be adjusted for `mark-xl` and `mark-iii`, etc. because they're pinned to specific versions.