### PR TITLE
Fix Telegram not appearing in LXQt 2.3.0 application menu

### DIFF
--- a/desktop-kit/autogen.kit.d/base.yml
+++ b/desktop-kit/autogen.kit.d/base.yml
@@ -153,11 +153,13 @@ net-im_github:
               exeinto /usr/lib/${PN}
               doexe "Telegram"
               newbin "${FILESDIR}"/${PN} "telegram-desktop"
+              dosym telegram-desktop /usr/bin/Telegram
               local icon_size
               for icon_size in 16 32 128 256 512; do
                 newicon -s "${icon_size}" \
                   "${SOURCE_DIR}/Telegram/Telegram/Images.xcassets/Icon.iconset/icon_${icon_size}x${icon_size}.png" \
                   telegram.png
+                dosym telegram.png /usr/share/icons/hicolor/${icon_size}x${icon_size}/apps/org.telegram.desktop.png
               done
               sed -i \
               -e '/SingleMainWindow=true/d' \


### PR DESCRIPTION
The Telegram desktop entry was not showing up in LXQt 2.3.0 because the expected binary name and icon name defined in the .desktop file were missing. The desktop file references Telegram as the executable and org.telegram.desktop as the icon, but the package only installed telegram-desktop and telegram.png, causing a mismatch.

This change adds a symlink for the binary (/usr/bin/Telegram -> telegram-desktop) and ensures the icon name expected by the desktop file is available by linking org.telegram.desktop.png to telegram.png in all icon sizes.

With these adjustments, LXQt correctly detects and displays Telegram in the application menu.