### PR TITLE
Update gnome3-utils.eclass

### DIFF
--- a/eclass/gnome3-utils.eclass
+++ b/eclass/gnome3-utils.eclass
@@ -354,7 +354,7 @@ gnome3_gdk_pixbuf_update() {
 	local tmp_file=$(emktemp)
 	${updater} 1> "${tmp_file}" &&
 	chmod 0644 "${tmp_file}" &&
-	cp -f "${tmp_file}" "${EROOT}usr/$(get_libdir)/gdk-pixbuf-2.0/2.10.0/loaders.cache" &&
+	cp -f "${tmp_file}" "${EROOT}/usr/$(get_libdir)/gdk-pixbuf-2.0/2.10.0/loaders.cache" &&
 	rm "${tmp_file}" # don't replace this with mv, required for SELinux support
 	eend $?
 }


### PR DESCRIPTION
fix https://github.com/macaroni-os/mark-issues/issues/664

The issue shown in the log is caused by gdk-pixbuf failing to load certain image formats because the loaders.cache was not properly updated during installation, due to a broken path in the eclass that prevented gdk-pixbuf-query-loaders from writing to the correct absolute location.

[gparted.log](https://github.com/user-attachments/files/27298164/gparted.log)
