### PR TITLE
new elogind-257.13 patch

### DIFF
--- a/security-kit/autogen.kit.d/security.yml
+++ b/security-kit/autogen.kit.d/security.yml
@@ -151,9 +151,7 @@ sys_auth_pkgs:
             - xdg-utils
           iuse: +acl audit cgroup-hybrid debug doc +pam +policykit
           patches:
-            - elogind-252.9-nodocs.patch
-            - elogind-255.17-revert-s2idle.patch
-            - elogind-255.22-revert-openrc-user.patch
+            - elogind-257.13-nodocs.patch
           bdepend: |
             app-text/docbook-xml-dtd:4.2
             app-text/docbook-xml-dtd:4.5


### PR DESCRIPTION
This new elogind-257.13-nodocs.patch is required to build elogind 257.13 correctly because the upstream meson.build documentation section was reorganized, causing the old elogind-252.9-nodocs.patch to fail with rejected hunks during src_prepare().