### PR TITLE
[kde-kit] Autogen libqaccessibilityclient

### DIFF
--- a/kde-kit/autogen.kit.d/base.yml
+++ b/kde-kit/autogen.kit.d/base.yml
@@ -790,3 +790,55 @@ calamares:
 
   packages:
     - calamares:
+
+libqaccessibilityclient:
+  generator: builtin-dirlisting
+  template:
+    engine: helm
+
+  defaults:
+    files_dir: "{{ .Values.pn }}"
+    template: ../../templates/simple.tmpl
+    category: media-libs
+    dir:
+      url: 'https://download.kde.org/Attic/libqaccessibilityclient/'
+      matcher: "libqaccessibilityclient-[0-9.]+\\.tar\\.xz$"
+    transform:
+      - kind: string
+        match: 'libqaccessibilityclient'
+        replace: ''
+      - kind: string
+        match: '.tar.xz'
+        replace: ''
+    assets:
+      - name: 'libqaccessibilityclient-{{ .Values.version }}.tar.xz'
+        url: 'https://download.kde.org/Attic/libqaccessibilityclient/libqaccessibilityclient-{{ .Values.version }}.tar.xz'
+    vars:
+      license: LGPL-2.1
+      qt_slot: '6'
+      homepage: https://invent.kde.org/libraries/libqaccessibilityclient
+      inherit:
+        - cmake
+      iuse: qt5 +qt6
+      required_use: '|| ( qt5 qt6 )'
+      rdepend: |
+        qt5? (
+          dev-qt/qtdbus:5
+          dev-qt/qtgui:5
+          dev-qt/qtwidgets:5
+        )
+        qt6? ( dev-qt/qtbase:{{ .Values.qt_slot }}[gui] )
+      depend: '${RDEPEND}'
+      bdepend: 'virtual/pkgconfig'
+
+  packages:
+    - libqaccessibilityclient:
+        vars:
+          desc: Accessibilty tools helper library, used e.g. by screen readers
+          body: |
+            src_configure() {
+              local mycmakeargs=(
+                -DQT_MAJOR_VERSION=$(usex qt6 6 5)
+              )
+              cmake_src_configure
+            }

--- a/kde-kit/autogen.kit.d/kde-apps.yaml
+++ b/kde-kit/autogen.kit.d/kde-apps.yaml
@@ -2397,7 +2397,7 @@ kde-apps:
             kde-frameworks/kio:{{ .Values.slot }}
             kde-frameworks/kwidgetsaddons:{{ .Values.slot }}
             kde-frameworks/kxmlgui:{{ .Values.slot }}
-            keyboardfocus? ( >=media-libs/libqaccessibilityclient-0.6:{{ .Values.slot }} )
+            keyboardfocus? ( media-libs/libqaccessibilityclient[qt6] )
 
     - kmahjongg:
         vars:

--- a/kde-kit/autogen.kit.d/kde-plasma.yaml
+++ b/kde-kit/autogen.kit.d/kde-plasma.yaml
@@ -988,7 +988,7 @@ kde-plasma:
             >=x11-libs/libxkbcommon-1.5.0
             x11-libs/xcb-util-cursor
             x11-libs/xcb-util-wm
-            accessibility? ( media-libs/libqaccessibilityclient:6 )
+            accessibility? ( media-libs/libqaccessibilityclient[qt6] )
             lock? ( kde-plasma/kscreenlocker:{{ .Values.slot }} )
             screencast? ( >=media-video/pipewire-1.2.0:= )
             shortcuts? ( kde-plasma/kglobalacceld:{{ .Values.slot }} )
@@ -1093,7 +1093,7 @@ kde-plasma:
             x11-libs/xcb-util-image
             x11-libs/xcb-util-keysyms
             x11-libs/xcb-util-wm
-            accessibility? ( media-libs/libqaccessibilityclient:{{ .Values.slot }} )
+            accessibility? ( media-libs/libqaccessibilityclient[qt6] )
             lock? ( kde-plasma/kscreenlocker:{{ .Values.slot }} )
             shortcuts? ( kde-plasma/kglobalacceld:{{ .Values.slot }} )
           depend: |

--- a/kde-kit/merge.kit.d/base_autogen.yml
+++ b/kde-kit/merge.kit.d/base_autogen.yml
@@ -31,6 +31,7 @@ target:
     - pkg: dev-libs/plasma-wayland-protocols
     - pkg: dev-libs/qcoro
 
+    - pkg: media-libs/libqaccessibilityclient
     - pkg: media-libs/phonon
     - pkg: media-libs/phonon-vlc
     - pkg: media-libs/pulseaudio-qt


### PR DESCRIPTION
Autogen added with qt5 and qt6 use flags to allow backwards compatibility for now
[closes]: macaroni-os/mark-issues#682