### PR TITLE
dev-lang/go: fix GOARCH detection for armv7a CHOST values on arm32bit…

### DIFF
--- a/lang-kit/autogen.kit.d/base.yml
+++ b/lang-kit/autogen.kit.d/base.yml
@@ -73,7 +73,7 @@ golang:
             aarch64) export GOARCH="arm64" ;;
             armel)   export GOARCH="arm" GOARM=5 ;;
             armhf)   export GOARCH="arm" GOARM=6 ;;
-            armv7)   export GOARCH="arm" GOARM=7 ;;
+            armv7*)   export GOARCH="arm" GOARM=7 ;;
             s390x)   export GOARCH="s390x" ;;
             x86)     export GOARCH="386" ;;
             x86_64)  export GOARCH="amd64" ;;


### PR DESCRIPTION
…: Update base.yml

The current ebuild only matches:

    armv7) export GOARCH="arm" GOARM=7 ;;

However, many modern ARM32 profiles use CHOST values such as:

    armv7a-unknown-linux-gnueabihf

This makes:

    CARCH=${CHOST%%-*}

expand to:

    armv7a

which does not match the existing armv7 case and falls through to:

    export GOARCH="unsupported"

causing the Go bootstrap to fail with:

    go tool dist: unknown $GOARCH unsupported

Build log excerpt:

    + CARCH=${CHOST%%-*}
    + case "$CARCH" in ...
    + export GOARCH="unsupported" ... go tool dist: unknown $GOARCH unsupported

Minimal fix:

    - armv7)   export GOARCH="arm" GOARM=7 ;;
    + armv7*)  export GOARCH="arm" GOARM=7 ;;

This allows armv7a, armv7hl and similar CHOST variants to build correctly.