### PR TITLE
[dev-kit] Add proper failure handling for dev-libs/nss whip hooks - U…

### DIFF
--- a/dev-kit/autogen.kit.d/base.yml
+++ b/dev-kit/autogen.kit.d/base.yml
@@ -512,10 +512,10 @@ linear_packages:
                 > "${ED}"/etc/prelink.conf.d/nss.conf
             }
             pkg_postinst() {
-              whip h nss.postinst
+              whip h nss.postinst || die "Failed to run whip h nss.postinst"
             }
             pkg_postrm() {
-              whip h nss.postrm
+              whip h nss.postrm || die "Failed to run whip h nss.postrm"
             }
 
 


### PR DESCRIPTION
…pdate base.yml

This PR improves error handling for NSS whip hooks during postinst and postrm phases.

Current implementation does not explicitly abort the ebuild when the whip helper fails, which may leave the system with incomplete NSS hook execution or partially configured libraries.

The updated implementation adds proper failure checks using die:
```
pkg_postinst() {
    whip h nss.postinst || die "Failed to run whip h nss.postinst"
}

pkg_postrm() {
    whip h nss.postrm || die "Failed to run whip h nss.postrm"
}
```

This ensures that hook failures are immediately visible and prevents silent or inconsistent NSS installation states.