### PR TITLE
[dev-kit] Fix dev-libs/nss postinst fails on ARM32 systems due to har…

### DIFF
--- a/dev-kit/autogen.kit.d/base.yml
+++ b/dev-kit/autogen.kit.d/base.yml
@@ -512,10 +512,10 @@ linear_packages:
                 > "${ED}"/etc/prelink.conf.d/nss.conf
             }
             pkg_postinst() {
-              whip h nss.postinst
+              LIBS="/usr/$(get_libdir)" whip h nss.postinst || die "Failed to run whip h nss.postinst"
             }
             pkg_postrm() {
-              whip h nss.postrm
+              LIBS="/usr/$(get_libdir)" whip h nss.postrm || die "Failed to run whip h nss.postrm"
             }
 
 


### PR DESCRIPTION
…dcoded /usr/lib64/libfreebl3.so path

This PR improves error handling for NSS whip hooks during postinst and postrm phases.

Current implementation does not explicitly abort the ebuild when the whip helper fails, which may leave the system with incomplete NSS hook execution or partially configured libraries.

The updated implementation adds proper failure checks using die. Reported on https://github.com/macaroni-os/mark-issues/issues/695

This ensures that hook failures are immediately visible and prevents silent or inconsistent NSS installation states.