### PR TITLE
[dev-kit] Removed CRMF static library installation for dev-libs/nss-3…

### DIFF
--- a/dev-kit/autogen.kit.d/base.yml
+++ b/dev-kit/autogen.kit.d/base.yml
@@ -413,7 +413,7 @@ linear_packages:
               dodir /usr/$(get_libdir)
               cp -L */lib/*$(get_libname) "${ED}"/usr/$(get_libdir) || die "copying shared libs failed"
               local i
-              for i in crmf freebl nssb nssckfw ; do
+              for i in freebl nssb nssckfw ; do
                 cp -L */lib/lib${i}.a "${ED}"/usr/$(get_libdir) || die "copying libs failed"
               done
 


### PR DESCRIPTION
….124 - Update base.yml

NSS 3.124 removed CRMF from builds and manifests upstream, so libcrmf.a is no longer generated.

Because of this, the following install loop now fails:
```
for i in crmf freebl nssb nssckfw ; do
```

with:
```
cp: cannot stat '*/lib/libcrmf.a': No such file or directory
```

This change removes crmf from the static library installation list:
```
- for i in crmf freebl nssb nssckfw ; do
+ for i in freebl nssb nssckfw ; do
```

Reported on https://github.com/macaroni-os/mark-issues/issues/696