### PR TITLE
[net-kit] net-firewall/iptables-1.8.13: fix install failure when USE=…

### DIFF
--- a/net-kit/autogen.kit.d/base.yml
+++ b/net-kit/autogen.kit.d/base.yml
@@ -3442,8 +3442,8 @@ iptables_dirlisting:
           rm -f "${ED}"/sbin/iptables-restore
           rm -f "${ED}"/sbin/ip6tables-save
           rm -f "${ED}"/sbin/ip6tables-restore
-          rm "${ED}"/etc/ethertypes || die
-          rm "${ED}"/sbin/{arptables,ebtables}{,-{save,restore}} || die
+          rm "${ED}"/etc/ethertypes || ewarn "File /etc/ethertypes not present. Ignoring."
+          rm "${ED}"/sbin/{arptables,ebtables}{,-{save,restore}} || ewarn "Some legacy arptables/ebtables files were not present. Ignoring."
 
           if use nftables; then
             dosym xtables-nft-multi /sbin/iptables


### PR DESCRIPTION
…”-nftables”

iptables: avoid removing nftables-only files when USE=”-nftables”

When USE=”-nftables”, some nftables-related files and binaries are not installed by upstream anymore, causing the ebuild to fail during src_install() while trying to remove non-existent files such as /etc/ethertypes and arptables/ebtables nft wrappers.

This patch adds proper USE conditional checks so these removals only happen when USE=“nftables” is enabled, matching the actual installed file set and preventing installation failures on legacy-only builds.

Reported on: https://github.com/macaroni-os/mark-issues/issues/697