### PR TITLE
Update dracut-mark.conf

### DIFF
--- a/kernel-kit/autogen.kit.d/virtual/dracut-mark/dracut-mark.conf
+++ b/kernel-kit/autogen.kit.d/virtual/dracut-mark/dracut-mark.conf
@@ -1,8 +1,10 @@
 # Macaroni OS (MARK) Dracut Default parameters
 
-dracutmodules="rescue resume bash kernel-modules rootfs-block udev-rules usrmount base fs-lib shutdown terminfo shutdown"
+dracutmodules="rescue resume bash kernel-modules rootfs-block udev-rules usrmount base fs-lib shutdown terminfo crypt lvm mdraid shutdown"
+
+add_drivers+=" dm_mod dm_crypt "
 
 omit_dracutmodules="fcoe"
 
-# Quiet messages: failed to execute '/lib64/elogind/elogind-uaccess-command' '/lib64/elogind/elogind-uaccess-command /dev/dri/card0 ': No such file or directory
-install_items="/lib64/elogind/elogind-uaccess-command"
+# Quiet messages: failed to execute '/usr/lib/elogind/elogind-uaccess-command' '/usr/lib/elogind/elogind-uaccess-command /dev/dri/card0 ': No such file or directory
+install_items+=" /usr/lib/elogind/elogind /usr/lib/elogind/elogind-cgroups-agent /usr/lib/elogind/elogind-uaccess-command /usr/lib/elogind/elogind-userdbd /usr/lib/elogind/elogind-userwork "


### PR DESCRIPTION
This is just a small fix to adjust the path to the correct location: /usr/lib64/elogind/elogind-uaccess-command.