### PR TITLE
Fix libxml2-python removing Python bindings during install

### DIFF
--- a/python-modules-kit/autogen.kit.d/python.yml
+++ b/python-modules-kit/autogen.kit.d/python.yml
@@ -892,7 +892,13 @@ libxml2_python:
         src_install() {
           meson_src_install
           # Remove files supplied by libxml2 library
-          rm -r "${ED}"/usr/{$(get_libdir),bin,include} || die
+          rm -f "${ED}"/usr/bin/xml2-config || die
+          rm -f "${ED}"/usr/bin/xmlcatalog || die
+          rm -f "${ED}"/usr/bin/xmllint || die
+          rm -rf "${ED}"/usr/include || die
+          rm -f "${ED}"/usr/$(get_libdir)/libxml2.so* || die
+          rm -rf "${ED}"/usr/$(get_libdir)/pkgconfig || die
+          rm -rf "${ED}"/usr/$(get_libdir)/cmake || die
         }
 
   packages:


### PR DESCRIPTION
The previous install cleanup used:
```
rm -r "${ED}"/usr/{$(get_libdir),bin,include} || die
```

This was too aggressive because it removed the entire ${ED}/usr/lib directory. As a result, the Python bindings installed under site-packages were deleted during src_install(), causing import libxml2 to fail even though the package built successfully.

This patch replaces the broad directory removal with targeted cleanup of only the files already provided by dev-libs/libxml2, preserving the Python module and its installation path while still avoiding file collisions with the main libxml2 package.