### PR TITLE
Update bind-tools-21.tmpl to fix install error

### DIFF
--- a/net-kit/autogen.kit.d/templates/bind-tools-21.tmpl
+++ b/net-kit/autogen.kit.d/templates/bind-tools-21.tmpl
@@ -60,6 +60,11 @@ src_install() {
 
 	rm -r "${D}"/usr/bin/{arpaname,named*,nsec3hash} || die
 	rm -r "${D}"/usr/sbin || die
+
+	dodoc -r doc/arm doc/changelog doc/notes
+	rm -f "${D}"/usr/share/doc/${PF}/{ChangeLog,NEWS} || die
+	dosym arm/changelog.rst.bz2 /usr/share/doc/${PF}/ChangeLog
+	dosym arm/changelog.rst.bz2 /usr/share/doc/${PF}/NEWS
 }
 
 # vim: filetype=ebuild


### PR DESCRIPTION
While testing bind-tools-9.21.23, I noticed the following QA warnings:
```
>>> Installing (1 of 1) net-dns/bind-tools-9.21.23::net-kit
 * QA Notice: Symbolic link /usr/share/doc/bind-tools-9.21.23/ChangeLog points to /usr/share/doc/bind-tools-9.21.23/doc/arm/changelog.rst which does not exist.
 * QA Notice: Symbolic link /usr/share/doc/bind-tools-9.21.23/NEWS points to /usr/share/doc/bind-tools-9.21.23/doc/arm/changelog.rst which does not exist.
```

To fix this, I updated src_install() to install the required documentation directories and recreated the ChangeLog and NEWS symbolic links so they point to the actual compressed documentation installed by Portage.

```
src_install() {
    meson_src_install

    rm -r "${D}"/usr/bin/{arpaname,named*,nsec3hash} || die
    rm -r "${D}"/usr/sbin || die

    dodoc -r doc/arm doc/changelog doc/notes

    rm -f "${D}"/usr/share/doc/${PF}/{ChangeLog,NEWS} || die

    dosym arm/changelog.rst.bz2 /usr/share/doc/${PF}/ChangeLog
    dosym arm/changelog.rst.bz2 /usr/share/doc/${PF}/NEWS
}
```

This removes the QA warnings while keeping the documentation available and ensuring the symbolic links resolve correctly.